### PR TITLE
refactor: simplify all implemented packages

### DIFF
--- a/packages/actions/src/parse-input.ts
+++ b/packages/actions/src/parse-input.ts
@@ -1,30 +1,39 @@
-export async function parseInput(request: Request): Promise<Record<string, unknown>> {
+type ParsedBody = {
+  actionName: string | null;
+  input: Record<string, unknown>;
+};
+
+async function parseBody(request: Request): Promise<ParsedBody> {
   const contentType = request.headers.get("Content-Type") ?? "";
 
   if (contentType.includes("application/json")) {
     const body = await request.clone().json() as Record<string, unknown>;
     const { _action, ...input } = body;
-    return input;
+    return { actionName: typeof _action === "string" ? _action : null, input };
   }
 
   // formData (url-encoded or multipart)
   const formData = await request.clone().formData();
-  const entries: Record<string, unknown> = {};
+  const input: Record<string, unknown> = {};
+  let actionName: string | null = null;
+
   for (const [key, value] of formData.entries()) {
-    if (key === "_action") continue;
-    entries[key] = value;
+    if (key === "_action") {
+      actionName = typeof value === "string" ? value : null;
+    } else {
+      input[key] = value;
+    }
   }
-  return entries;
+
+  return { actionName, input };
+}
+
+export async function parseInput(request: Request): Promise<Record<string, unknown>> {
+  const { input } = await parseBody(request);
+  return input;
 }
 
 export async function extractActionName(request: Request): Promise<string | null> {
-  const contentType = request.headers.get("Content-Type") ?? "";
-
-  if (contentType.includes("application/json")) {
-    const body = await request.clone().json() as Record<string, unknown>;
-    return (body._action as string) ?? null;
-  }
-
-  const formData = await request.clone().formData();
-  return formData.get("_action") as string | null;
+  const { actionName } = await parseBody(request);
+  return actionName;
 }

--- a/packages/auth/src/__tests__/helpers.ts
+++ b/packages/auth/src/__tests__/helpers.ts
@@ -1,10 +1,8 @@
-import { definePermissions, grant } from "@cfast/permissions";
-
 // Minimal D1 mock that records calls and can return configurable results
 export function createMockD1(): D1Database & { _calls: Array<{ sql: string; params: unknown[] }> } {
   const calls: Array<{ sql: string; params: unknown[] }> = [];
 
-  let nextResults: unknown[] = [];
+  const nextResults: unknown[] = [];
 
   const mockResults = () => ({
     results: nextResults,
@@ -34,15 +32,5 @@ export function createMockD1(): D1Database & { _calls: Array<{ sql: string; para
     batch: async (stmts: unknown[]) => stmts.map(() => mockResults()),
     dump: async () => new ArrayBuffer(0),
     exec: async () => ({ count: 0, duration: 0 }),
-  } as any;
+  } as unknown as D1Database & { _calls: Array<{ sql: string; params: unknown[] }> };
 }
-
-// Simple test permissions for auth tests
-export const testPermissions = definePermissions({
-  roles: ["anonymous", "user", "admin"] as const,
-  grants: {
-    anonymous: [],
-    user: [grant("read", "all")],
-    admin: [grant("manage", "all")],
-  },
-});

--- a/packages/auth/src/client/auth-provider.tsx
+++ b/packages/auth/src/client/auth-provider.tsx
@@ -21,6 +21,14 @@ export function AuthProvider({
   );
 }
 
+function useAuthContext(hookName: string): AuthContextValue {
+  const ctx = useContext(AuthContext);
+  if (ctx === null) {
+    throw new Error(`${hookName} must be used within an <AuthProvider>`);
+  }
+  return ctx;
+}
+
 /**
  * Access the current user from the nearest AuthProvider.
  * Returns `AuthUser | null` — null when not authenticated.
@@ -28,20 +36,12 @@ export function AuthProvider({
  * Must be used within an `<AuthProvider>`.
  */
 export function useCurrentUser(): AuthUser | null {
-  const ctx = useContext(AuthContext);
-  if (ctx === null) {
-    throw new Error("useCurrentUser must be used within an <AuthProvider>");
-  }
-  return ctx.user;
+  return useAuthContext("useCurrentUser").user;
 }
 
 /**
  * Access the login path configured in the nearest AuthProvider.
  */
 export function useLoginPath(): string {
-  const ctx = useContext(AuthContext);
-  if (ctx === null) {
-    throw new Error("useLoginPath must be used within an <AuthProvider>");
-  }
-  return ctx.loginPath;
+  return useAuthContext("useLoginPath").loginPath;
 }

--- a/packages/auth/src/roles.ts
+++ b/packages/auth/src/roles.ts
@@ -16,17 +16,22 @@ export function createRoleManager(d1: D1Database) {
     },
 
     async setRoles(userId: string, roles: string[]): Promise<void> {
-      const deleteStmt = d1.prepare(
-        "DELETE FROM cfast_roles WHERE user_id = ?",
-      );
-      await deleteStmt.bind(userId).run();
+      const deleteStmt = d1
+        .prepare("DELETE FROM cfast_roles WHERE user_id = ?")
+        .bind(userId);
 
-      for (const role of roles) {
-        const insertStmt = d1.prepare(
-          "INSERT INTO cfast_roles (user_id, role) VALUES (?, ?)",
-        );
-        await insertStmt.bind(userId, role).run();
+      if (roles.length === 0) {
+        await deleteStmt.run();
+        return;
       }
+
+      const insertStmts = roles.map((role) =>
+        d1
+          .prepare("INSERT INTO cfast_roles (user_id, role) VALUES (?, ?)")
+          .bind(userId, role),
+      );
+
+      await d1.batch([deleteStmt, ...insertStmts]);
     },
 
     async removeRole(userId: string, role: string): Promise<void> {

--- a/packages/auth/src/route-handlers.ts
+++ b/packages/auth/src/route-handlers.ts
@@ -18,13 +18,9 @@ import type { AuthInstance } from "./types";
  * ```
  */
 export function createAuthRouteHandlers(getAuth: () => AuthInstance) {
-  async function loader({ request }: { request: Request }) {
+  function handleRequest({ request }: { request: Request }) {
     return getAuth().handler(request);
   }
 
-  async function action({ request }: { request: Request }) {
-    return getAuth().handler(request);
-  }
-
-  return { loader, action };
+  return { loader: handleRequest, action: handleRequest };
 }

--- a/packages/db/src/cache.ts
+++ b/packages/db/src/cache.ts
@@ -145,25 +145,19 @@ export function createCacheManager(config: CacheConfig): CacheManager {
             },
           }),
         );
-
-        if (typeof options === "object" && options?.tags) {
-          for (const tag of options.tags) {
-            if (!tagToKeys.has(tag)) tagToKeys.set(tag, new Set());
-            tagToKeys.get(tag)!.add(key);
-          }
-        }
       }
 
       if (config.backend === "kv" && config.kv) {
         await config.kv.put(key, JSON.stringify(value), {
           expirationTtl: ttl,
         });
+      }
 
-        if (typeof options === "object" && options?.tags) {
-          for (const tag of options.tags) {
-            if (!tagToKeys.has(tag)) tagToKeys.set(tag, new Set());
-            tagToKeys.get(tag)!.add(key);
-          }
+      // Track tags for invalidation (works for both backends)
+      if (typeof options === "object" && options?.tags) {
+        for (const tag of options.tags) {
+          if (!tagToKeys.has(tag)) tagToKeys.set(tag, new Set());
+          tagToKeys.get(tag)!.add(key);
         }
       }
     },

--- a/packages/db/src/compose.ts
+++ b/packages/db/src/compose.ts
@@ -1,26 +1,5 @@
-import type { PermissionDescriptor } from "@cfast/permissions";
+import { deduplicateDescriptors } from "./utils";
 import type { Operation } from "./types";
-
-function deduplicateDescriptors(
-  descriptors: PermissionDescriptor[],
-): PermissionDescriptor[] {
-  const seen = new Set<string>();
-  const result: PermissionDescriptor[] = [];
-
-  for (const d of descriptors) {
-    const tableName = (d.table as any)._?.name
-      ?? (d.table as any)[Symbol.for("drizzle:Name")]
-      ?? (d.table as any)[Symbol.for("drizzle:BaseName")]
-      ?? "unknown";
-    const key = `${d.action}:${tableName}`;
-    if (!seen.has(key)) {
-      seen.add(key);
-      result.push(d);
-    }
-  }
-
-  return result;
-}
 
 type RunFn = (params: Record<string, unknown>) => Promise<unknown>;
 

--- a/packages/db/src/create-db.ts
+++ b/packages/db/src/create-db.ts
@@ -1,27 +1,9 @@
-import type { DrizzleTable, PermissionDescriptor } from "@cfast/permissions";
+import type { DrizzleTable } from "@cfast/permissions";
 import { createQueryBuilder } from "./query-builder";
 import { createInsertBuilder, createUpdateBuilder, createDeleteBuilder } from "./mutate-builder";
 import { createCacheManager, type CacheManager } from "./cache";
+import { deduplicateDescriptors } from "./utils";
 import type { Db, DbConfig, Operation } from "./types";
-
-function deduplicateDescriptors(
-  descriptors: PermissionDescriptor[],
-): PermissionDescriptor[] {
-  const seen = new Set<string>();
-  const result: PermissionDescriptor[] = [];
-  for (const d of descriptors) {
-    const tableName = (d.table as any)._?.name
-      ?? (d.table as any)[Symbol.for("drizzle:Name")]
-      ?? (d.table as any)[Symbol.for("drizzle:BaseName")]
-      ?? "unknown";
-    const key = `${d.action}:${tableName}`;
-    if (!seen.has(key)) {
-      seen.add(key);
-      result.push(d);
-    }
-  }
-  return result;
-}
 
 export function createDb(config: DbConfig): Db {
   return buildDb(config, false);

--- a/packages/db/src/mutate-builder.ts
+++ b/packages/db/src/mutate-builder.ts
@@ -1,10 +1,9 @@
 import { drizzle } from "drizzle-orm/d1";
-import { and, or } from "drizzle-orm";
 import type { Grant, PermissionDescriptor, DrizzleTable, PermissionAction } from "@cfast/permissions";
-import { resolvePermissionFilters, checkOperationPermissions } from "./permissions";
+import { checkOperationPermissions } from "./permissions";
+import { buildPermissionFilter, combineWhere, makePermissions, getTableName } from "./utils";
+import type { User } from "./utils";
 import type { Operation } from "./types";
-
-type User = { id: string };
 
 type MutateBuilderConfig = {
   d1: D1Database;
@@ -16,115 +15,78 @@ type MutateBuilderConfig = {
   onMutate?: (tableName: string) => void;
 };
 
-function makePermissions(
+function checkIfNeeded(config: MutateBuilderConfig, grants: Grant[], permissions: PermissionDescriptor[]): void {
+  if (!config.unsafe) {
+    checkOperationPermissions(grants, permissions);
+  }
+}
+
+function buildMutationWithReturning(
   config: MutateBuilderConfig,
-  action: PermissionAction,
-): PermissionDescriptor[] {
-  return config.unsafe ? [] : [{ action, table: config.table }];
-}
-
-function buildMutatePermissionFilter(
-  config: MutateBuilderConfig,
-  action: PermissionAction,
-): unknown {
-  if (config.unsafe || !config.user) return undefined;
-  const filters = resolvePermissionFilters(config.grants, action, config.table);
-  if (filters.length === 0) return undefined;
-  const columns = config.table as Record<string, unknown>;
-  const clauses = filters.map((fn) => fn(columns, config.user!));
-  return clauses.length === 1 ? clauses[0] : or(...(clauses as [any, ...any[]]));
-}
-
-function combineWhere(userCondition: unknown, permFilter: unknown): unknown {
-  if (permFilter && userCondition) return and(userCondition as any, permFilter as any);
-  return (permFilter ?? userCondition) as any;
-}
-
-function getTableName(table: DrizzleTable): string {
-  return (table as any)._?.name ?? (table as any)[Symbol.for("drizzle:Name")] ?? "unknown";
+  permissions: PermissionDescriptor[],
+  tableName: string,
+  execute: (returning: boolean) => Promise<unknown>,
+): Operation<void> & { returning: () => Operation<unknown> } {
+  return {
+    permissions,
+    async run(_params: Record<string, unknown>): Promise<void> {
+      checkIfNeeded(config, config.grants, permissions);
+      await execute(false);
+      config.onMutate?.(tableName);
+    },
+    returning() {
+      return {
+        permissions,
+        async run(_params: Record<string, unknown>): Promise<unknown> {
+          checkIfNeeded(config, config.grants, permissions);
+          const result = await execute(true);
+          config.onMutate?.(tableName);
+          return result;
+        },
+      };
+    },
+  };
 }
 
 export function createInsertBuilder(config: MutateBuilderConfig) {
   const db = drizzle(config.d1, { schema: config.schema as Record<string, any> });
-  const permissions = makePermissions(config, "create");
+  const permissions = makePermissions(config.unsafe, "create", config.table);
   const tableName = getTableName(config.table);
 
   return {
     values(values: Record<string, unknown>) {
-      const base: Operation<void> & { returning: () => Operation<unknown> } = {
-        permissions,
-        async run(_params: Record<string, unknown>): Promise<void> {
-          if (!config.unsafe) {
-            checkOperationPermissions(config.grants, permissions);
-          }
-          await db.insert(config.table as any).values(values).run();
-          config.onMutate?.(tableName);
-        },
-        returning() {
-          return {
-            permissions,
-            async run(_params: Record<string, unknown>): Promise<unknown> {
-              if (!config.unsafe) {
-                checkOperationPermissions(config.grants, permissions);
-              }
-              const result = await db
-                .insert(config.table as any)
-                .values(values)
-                .returning()
-                .get();
-              config.onMutate?.(tableName);
-              return result;
-            },
-          };
-        },
-      };
-      return base;
+      return buildMutationWithReturning(config, permissions, tableName, async (returning) => {
+        const query = db.insert(config.table as any).values(values);
+        if (returning) {
+          return query.returning().get();
+        }
+        await query.run();
+      });
     },
   };
 }
 
 export function createUpdateBuilder(config: MutateBuilderConfig) {
   const db = drizzle(config.d1, { schema: config.schema as Record<string, any> });
-  const permissions = makePermissions(config, "update");
+  const permissions = makePermissions(config.unsafe, "update", config.table);
   const tableName = getTableName(config.table);
 
   return {
     set(values: Record<string, unknown>) {
       return {
         where(condition: unknown) {
-          const base: Operation<void> & { returning: () => Operation<unknown> } = {
-            permissions,
-            async run(_params: Record<string, unknown>): Promise<void> {
-              if (!config.unsafe) {
-                checkOperationPermissions(config.grants, permissions);
-              }
-              const permFilter = buildMutatePermissionFilter(config, "update");
-              const combinedWhere = combineWhere(condition, permFilter);
-              await db.update(config.table as any).set(values).where(combinedWhere as any).run();
-              config.onMutate?.(tableName);
-            },
-            returning() {
-              return {
-                permissions,
-                async run(_params: Record<string, unknown>): Promise<unknown> {
-                  if (!config.unsafe) {
-                    checkOperationPermissions(config.grants, permissions);
-                  }
-                  const permFilter = buildMutatePermissionFilter(config, "update");
-                  const combinedWhere = combineWhere(condition, permFilter);
-                  const result = await db
-                    .update(config.table as any)
-                    .set(values)
-                    .where(combinedWhere as any)
-                    .returning()
-                    .get();
-                  config.onMutate?.(tableName);
-                  return result;
-                },
-              };
-            },
-          };
-          return base;
+          const permFilter = buildPermissionFilter(
+            config.grants, "update", config.table, config.user, config.unsafe,
+          );
+          const combinedWhere = combineWhere(condition, permFilter);
+
+          return buildMutationWithReturning(config, permissions, tableName, async (returning) => {
+            const query = db.update(config.table as any).set(values).where(combinedWhere as any);
+            if (returning) {
+              return query.returning().get();
+            }
+            await query.run();
+          });
         },
       };
     },
@@ -133,43 +95,23 @@ export function createUpdateBuilder(config: MutateBuilderConfig) {
 
 export function createDeleteBuilder(config: MutateBuilderConfig) {
   const db = drizzle(config.d1, { schema: config.schema as Record<string, any> });
-  const permissions = makePermissions(config, "delete");
+  const permissions = makePermissions(config.unsafe, "delete", config.table);
   const tableName = getTableName(config.table);
 
   return {
     where(condition: unknown) {
-      const base: Operation<void> & { returning: () => Operation<unknown> } = {
-        permissions,
-        async run(_params: Record<string, unknown>): Promise<void> {
-          if (!config.unsafe) {
-            checkOperationPermissions(config.grants, permissions);
-          }
-          const permFilter = buildMutatePermissionFilter(config, "delete");
-          const combinedWhere = combineWhere(condition, permFilter);
-          await db.delete(config.table as any).where(combinedWhere as any).run();
-          config.onMutate?.(tableName);
-        },
-        returning() {
-          return {
-            permissions,
-            async run(_params: Record<string, unknown>): Promise<unknown> {
-              if (!config.unsafe) {
-                checkOperationPermissions(config.grants, permissions);
-              }
-              const permFilter = buildMutatePermissionFilter(config, "delete");
-              const combinedWhere = combineWhere(condition, permFilter);
-              const result = await db
-                .delete(config.table as any)
-                .where(combinedWhere as any)
-                .returning()
-                .get();
-              config.onMutate?.(tableName);
-              return result;
-            },
-          };
-        },
-      };
-      return base;
+      const permFilter = buildPermissionFilter(
+        config.grants, "delete", config.table, config.user, config.unsafe,
+      );
+      const combinedWhere = combineWhere(condition, permFilter);
+
+      return buildMutationWithReturning(config, permissions, tableName, async (returning) => {
+        const query = db.delete(config.table as any).where(combinedWhere as any);
+        if (returning) {
+          return query.returning().get();
+        }
+        await query.run();
+      });
     },
   };
 }

--- a/packages/db/src/query-builder.ts
+++ b/packages/db/src/query-builder.ts
@@ -1,10 +1,9 @@
 import { drizzle } from "drizzle-orm/d1";
-import { and, or } from "drizzle-orm";
-import type { Grant, PermissionDescriptor, DrizzleTable } from "@cfast/permissions";
-import { resolvePermissionFilters, checkOperationPermissions } from "./permissions";
+import type { Grant, DrizzleTable } from "@cfast/permissions";
+import { checkOperationPermissions } from "./permissions";
+import { buildPermissionFilter, combineWhere, makePermissions } from "./utils";
+import type { User } from "./utils";
 import type { Operation, FindManyOptions, FindFirstOptions } from "./types";
-
-type User = { id: string };
 
 type QueryBuilderConfig = {
   d1: D1Database;
@@ -22,17 +21,38 @@ function getTableKey(schema: Record<string, unknown>, table: DrizzleTable): stri
   return undefined;
 }
 
-function buildPermissionFilter(
+function buildQueryOperation<TResult>(
   config: QueryBuilderConfig,
-  table: DrizzleTable,
-): unknown {
-  if (config.unsafe || !config.user) return undefined;
-  const filters = resolvePermissionFilters(config.grants, "read", table);
-  if (filters.length === 0) return undefined;
+  db: ReturnType<typeof drizzle>,
+  tableKey: string,
+  method: "findMany" | "findFirst",
+  options?: FindManyOptions | FindFirstOptions,
+): Operation<TResult> {
+  const permissions = makePermissions(config.unsafe, "read", config.table);
 
-  const columns = table as Record<string, unknown>;
-  const clauses = filters.map((fn) => fn(columns, config.user!));
-  return clauses.length === 1 ? clauses[0] : or(...(clauses as [any, ...any[]]));
+  return {
+    permissions,
+    async run(_params: Record<string, unknown>): Promise<TResult> {
+      if (!config.unsafe) {
+        checkOperationPermissions(config.grants, permissions);
+      }
+
+      const permFilter = buildPermissionFilter(
+        config.grants, "read", config.table, config.user, config.unsafe,
+      );
+      const userWhere = options?.where;
+      const combinedWhere = combineWhere(userWhere, permFilter);
+
+      const queryOptions: Record<string, unknown> = { ...options };
+      if (combinedWhere) {
+        queryOptions.where = combinedWhere;
+      }
+      delete queryOptions.cache;
+
+      const result = await (db.query as any)[tableKey][method](queryOptions);
+      return (method === "findFirst" ? result ?? undefined : result) as TResult;
+    },
+  };
 }
 
 export function createQueryBuilder(config: QueryBuilderConfig) {
@@ -41,67 +61,23 @@ export function createQueryBuilder(config: QueryBuilderConfig) {
 
   return {
     findMany(options?: FindManyOptions): Operation<unknown[]> {
-      const permissions: PermissionDescriptor[] = config.unsafe
-        ? []
-        : [{ action: "read" as const, table: config.table }];
-
-      return {
-        permissions,
-        async run(_params: Record<string, unknown>): Promise<unknown[]> {
-          if (!config.unsafe) {
-            checkOperationPermissions(config.grants, permissions);
-          }
-
-          if (!tableKey) throw new Error("Table not found in schema");
-
-          const permFilter = buildPermissionFilter(config, config.table);
-          const userWhere = options?.where;
-          const combinedWhere = permFilter && userWhere
-            ? and(userWhere as any, permFilter as any)
-            : (permFilter ?? userWhere) as any;
-
-          const queryOptions: Record<string, unknown> = { ...options };
-          if (combinedWhere) {
-            queryOptions.where = combinedWhere;
-          }
-          delete queryOptions.cache; // cache is not a Drizzle option
-
-          const result = await (db.query as any)[tableKey].findMany(queryOptions);
-          return result;
-        },
-      };
+      if (!tableKey) {
+        return {
+          permissions: makePermissions(config.unsafe, "read", config.table),
+          async run(): Promise<unknown[]> { throw new Error("Table not found in schema"); },
+        };
+      }
+      return buildQueryOperation<unknown[]>(config, db, tableKey, "findMany", options);
     },
 
     findFirst(options?: FindFirstOptions): Operation<unknown | undefined> {
-      const permissions: PermissionDescriptor[] = config.unsafe
-        ? []
-        : [{ action: "read" as const, table: config.table }];
-
-      return {
-        permissions,
-        async run(_params: Record<string, unknown>): Promise<unknown | undefined> {
-          if (!config.unsafe) {
-            checkOperationPermissions(config.grants, permissions);
-          }
-
-          if (!tableKey) throw new Error("Table not found in schema");
-
-          const permFilter = buildPermissionFilter(config, config.table);
-          const userWhere = options?.where;
-          const combinedWhere = permFilter && userWhere
-            ? and(userWhere as any, permFilter as any)
-            : (permFilter ?? userWhere) as any;
-
-          const queryOptions: Record<string, unknown> = { ...options };
-          if (combinedWhere) {
-            queryOptions.where = combinedWhere;
-          }
-          delete queryOptions.cache;
-
-          const result = await (db.query as any)[tableKey].findFirst(queryOptions);
-          return result ?? undefined;
-        },
-      };
+      if (!tableKey) {
+        return {
+          permissions: makePermissions(config.unsafe, "read", config.table),
+          async run(): Promise<unknown | undefined> { throw new Error("Table not found in schema"); },
+        };
+      }
+      return buildQueryOperation<unknown | undefined>(config, db, tableKey, "findFirst", options);
     },
   };
 }

--- a/packages/db/src/utils.ts
+++ b/packages/db/src/utils.ts
@@ -1,0 +1,55 @@
+import { and, or } from "drizzle-orm";
+import type { DrizzleTable, Grant, PermissionAction, PermissionDescriptor } from "@cfast/permissions";
+import { resolvePermissionFilters } from "./permissions";
+
+export type User = { id: string };
+
+export function getTableName(table: DrizzleTable): string {
+  return (table as any)._?.name
+    ?? (table as any)[Symbol.for("drizzle:Name")]
+    ?? (table as any)[Symbol.for("drizzle:BaseName")]
+    ?? "unknown";
+}
+
+export function deduplicateDescriptors(
+  descriptors: PermissionDescriptor[],
+): PermissionDescriptor[] {
+  const seen = new Set<string>();
+  const result: PermissionDescriptor[] = [];
+  for (const d of descriptors) {
+    const key = `${d.action}:${getTableName(d.table as DrizzleTable)}`;
+    if (!seen.has(key)) {
+      seen.add(key);
+      result.push(d);
+    }
+  }
+  return result;
+}
+
+export function buildPermissionFilter(
+  grants: Grant[],
+  action: PermissionAction,
+  table: DrizzleTable,
+  user: User | null,
+  unsafe: boolean,
+): unknown {
+  if (unsafe || !user) return undefined;
+  const filters = resolvePermissionFilters(grants, action, table);
+  if (filters.length === 0) return undefined;
+  const columns = table as Record<string, unknown>;
+  const clauses = filters.map((fn) => fn(columns, user));
+  return clauses.length === 1 ? clauses[0] : or(...(clauses as [any, ...any[]]));
+}
+
+export function combineWhere(userCondition: unknown, permFilter: unknown): unknown {
+  if (permFilter && userCondition) return and(userCondition as any, permFilter as any);
+  return (permFilter ?? userCondition) as any;
+}
+
+export function makePermissions(
+  unsafe: boolean,
+  action: PermissionAction,
+  table: DrizzleTable,
+): PermissionDescriptor[] {
+  return unsafe ? [] : [{ action, table }];
+}

--- a/packages/email/src/create-email-client.ts
+++ b/packages/email/src/create-email-client.ts
@@ -4,8 +4,10 @@ import type { EmailClient, EmailClientConfig, SendOptions } from "./types.js";
 export function createEmailClient(config: EmailClientConfig): EmailClient {
   return {
     async send(options: SendOptions): Promise<{ id: string }> {
-      const html = await render(options.react);
-      const text = await render(options.react, { plainText: true });
+      const [html, text] = await Promise.all([
+        render(options.react),
+        render(options.react, { plainText: true }),
+      ]);
 
       const from =
         options.from ??

--- a/packages/env/src/define-env.ts
+++ b/packages/env/src/define-env.ts
@@ -1,4 +1,4 @@
-import type { Schema, ParsedEnv, BindingDef, EnvironmentName } from "./types";
+import type { Schema, ParsedEnv, BindingDef, EnvironmentName, EnvValidationError } from "./types";
 import { EnvError } from "./errors";
 import { validateBinding } from "./validators";
 
@@ -47,17 +47,15 @@ export function defineEnv<S extends Schema>(schema: S): Env<S> {
         ]);
       }
 
-      const environment: EnvironmentName = rawEnvironment;
-
-      const errors: { key: string; message: string }[] = [];
+      const errors: EnvValidationError[] = [];
       const result: Record<string, unknown> = {};
 
       for (const [key, def] of Object.entries(schema)) {
         let value = rawEnv[key];
 
         // Apply defaults for var bindings
-        if (value === undefined || value === null) {
-          const defaultValue = resolveDefault(def, environment);
+        if (value == null) {
+          const defaultValue = resolveDefault(def, rawEnvironment);
           if (defaultValue !== undefined) {
             value = defaultValue;
           } else if (
@@ -68,7 +66,7 @@ export function defineEnv<S extends Schema>(schema: S): Env<S> {
             // Environment-aware default with no matching key for this environment
             errors.push({
               key,
-              message: `Missing required variable '${key}'. No default for environment '${environment}'.`,
+              message: `Missing required variable '${key}'. No default for environment '${rawEnvironment}'.`,
             });
             continue;
           }

--- a/packages/env/src/validators.ts
+++ b/packages/env/src/validators.ts
@@ -1,6 +1,6 @@
-import type { BindingDef, EnvValidationError } from "./types";
+import type { BindingDef, BindingType, EnvValidationError } from "./types";
 
-const BINDING_LABELS: Record<string, string> = {
+const BINDING_LABELS: Record<BindingType, string> = {
   d1: "D1",
   kv: "KV",
   r2: "R2",
@@ -33,11 +33,11 @@ export function validateBinding(
   def: BindingDef,
   value: unknown,
 ): EnvValidationError | undefined {
-  const label = BINDING_LABELS[def.type] ?? def.type;
+  const label = BINDING_LABELS[def.type];
 
   // For var bindings, defaults must be resolved by the caller before calling validateBinding.
   if (def.type === "var") {
-    if (value === undefined || value === null) {
+    if (value == null) {
       return { key, message: `Missing required variable '${key}'. Check your wrangler.toml.` };
     }
     if (typeof value !== "string") {
@@ -50,7 +50,7 @@ export function validateBinding(
   }
 
   if (def.type === "secret") {
-    if (value === undefined || value === null) {
+    if (value == null) {
       return { key, message: `Missing required secret '${key}'. Check your wrangler.toml.` };
     }
     if (typeof value !== "string") {
@@ -63,7 +63,7 @@ export function validateBinding(
   }
 
   // Object bindings: d1, kv, r2, queue, durable-object, service
-  if (value === undefined || value === null) {
+  if (value == null) {
     return { key, message: `Missing required ${label} binding '${key}'. Check your wrangler.toml.` };
   }
 

--- a/packages/permissions/src/check.ts
+++ b/packages/permissions/src/check.ts
@@ -1,47 +1,34 @@
 import type {
-  DrizzleTable,
   Grant,
   PermissionAction,
   PermissionCheckResult,
   PermissionDescriptor,
   Permissions,
 } from "./types";
-import { CRUD_ACTIONS } from "./types";
+import { CRUD_ACTIONS, getTableName } from "./types";
 
-function getTableName(table: DrizzleTable): string {
-  return table._?.name ?? "unknown";
-}
-
-function grantMatchesAction(
-  grantAction: PermissionAction,
-  requiredAction: PermissionAction,
+function grantMatches(
+  g: Grant,
+  action: PermissionAction,
+  table: PermissionDescriptor["table"],
 ): boolean {
-  if (grantAction === requiredAction) return true;
-  if (grantAction === "manage") return true;
-  return false;
-}
-
-function grantMatchesTable(
-  grantSubject: DrizzleTable | "all",
-  requiredTable: DrizzleTable,
-): boolean {
-  if (grantSubject === "all") return true;
-  return grantSubject === requiredTable;
+  const actionOk = g.action === action || g.action === "manage";
+  const subjectOk = g.subject === "all" || g.subject === table;
+  return actionOk && subjectOk;
 }
 
 function hasGrantFor(
   grants: Grant[],
   action: PermissionAction,
-  table: DrizzleTable,
+  table: PermissionDescriptor["table"],
 ): boolean {
-  return grants.some(
-    (g) =>
-      grantMatchesAction(g.action, action) &&
-      grantMatchesTable(g.subject, table),
-  );
+  return grants.some((g) => grantMatches(g, action, table));
 }
 
-function hasManagePermission(grants: Grant[], table: DrizzleTable): boolean {
+function hasManagePermission(
+  grants: Grant[],
+  table: PermissionDescriptor["table"],
+): boolean {
   if (hasGrantFor(grants, "manage", table)) return true;
   return CRUD_ACTIONS.every((action) => hasGrantFor(grants, action, table));
 }

--- a/packages/permissions/src/define-permissions.ts
+++ b/packages/permissions/src/define-permissions.ts
@@ -1,16 +1,5 @@
-import type { DrizzleTable, Grant, GrantFn, Permissions, PermissionsConfig, WhereClause, PermissionAction } from "./types";
-
-function createGrantFn<TUser>(): GrantFn<TUser> {
-  return (
-    action: PermissionAction,
-    subject: DrizzleTable | "all",
-    options?: { where?: (columns: Record<string, unknown>, user: TUser) => any },
-  ): Grant => ({
-    action,
-    subject,
-    where: options?.where as WhereClause | undefined,
-  });
-}
+import type { Grant, GrantFn, Permissions, PermissionsConfig } from "./types";
+import { grant } from "./grant";
 
 function buildPermissions<TRoles extends readonly string[]>(
   config: PermissionsConfig<TRoles>,
@@ -19,7 +8,7 @@ function buildPermissions<TRoles extends readonly string[]>(
 
   const grants =
     typeof config.grants === "function"
-      ? config.grants(createGrantFn())
+      ? config.grants(grant as GrantFn<unknown>)
       : config.grants;
 
   const resolvedGrants = resolveHierarchy(roles, grants, hierarchy);

--- a/packages/permissions/src/errors.ts
+++ b/packages/permissions/src/errors.ts
@@ -1,8 +1,5 @@
 import type { DrizzleTable, PermissionAction, PermissionDescriptor } from "./types";
-
-function getTableName(table: DrizzleTable): string {
-  return table._?.name ?? "unknown";
-}
+import { getTableName } from "./types";
 
 type ForbiddenErrorOptions = {
   action: PermissionAction;

--- a/packages/permissions/src/resolve-grants.ts
+++ b/packages/permissions/src/resolve-grants.ts
@@ -29,8 +29,8 @@ export function resolveGrants(
   type GroupKey = string;
   const groups = new Map<GroupKey, { action: Grant["action"]; subject: Grant["subject"]; wheres: Array<Grant["where"]> }>();
 
-  // We need a way to create unique keys for action+subject pairs
-  // where subject identity is by reference. Use a WeakMap for table references.
+  // Create unique keys for action+subject pairs using reference identity.
+  // A regular Map is needed since "all" is a string (not valid for WeakMap).
   const subjectIds = new Map<Grant["subject"], number>();
   let nextId = 0;
 

--- a/packages/permissions/src/types.ts
+++ b/packages/permissions/src/types.ts
@@ -5,6 +5,10 @@
 export type DrizzleTable = { _: { name: string } };
 export type DrizzleSQL = { getSQL(): unknown };
 
+export function getTableName(table: DrizzleTable): string {
+  return table._?.name ?? "unknown";
+}
+
 export type PermissionAction = "read" | "create" | "update" | "delete" | "manage";
 
 export type CrudAction = Exclude<PermissionAction, "manage">;


### PR DESCRIPTION
## Summary

- **permissions**: Extract shared `getTableName`, merge `grantMatchesAction`+`grantMatchesTable` into single `grantMatches`, eliminate duplicated grant factory
- **env**: Use `EnvValidationError` type instead of inline anonymous type, simplify nullish checks to `== null`, tighten `BINDING_LABELS` to `Record<BindingType, string>`
- **db**: Extract 5 duplicated utilities into shared `utils.ts` (`deduplicateDescriptors`, `getTableName`, `buildPermissionFilter`, `combineWhere`, `makePermissions`), unify `findMany`/`findFirst` and mutation `run`/`returning().run` patterns, deduplicate cache tag tracking
- **auth**: Batch N+1 SQL in `setRoles` into single `d1.batch()`, deduplicate context hook guards, unify identical `loader`/`action` handlers, clean up test helpers
- **email**: Concurrent HTML+plaintext `render()` via `Promise.all`
- **actions**: Extract shared `parseBody` from duplicated request parsing, replace `as` casts with runtime type guards

Net reduction: ~150 lines across 19 files. All tests pass (15 suites), all typechecks pass (23 tasks).

## Test plan
- [x] `pnpm test` — all 15 test suites pass
- [x] `pnpm typecheck` — all 23 tasks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)