### PR TITLE
feat(example): use @cfast/pagination in team-blog-after

### DIFF
--- a/examples/team-blog-after/app/routes/admin.posts.tsx
+++ b/examples/team-blog-after/app/routes/admin.posts.tsx
@@ -6,19 +6,27 @@ import Button from "@mui/joy/Button";
 import Chip from "@mui/joy/Chip";
 import Stack from "@mui/joy/Stack";
 import Typography from "@mui/joy/Typography";
-import Tabs from "@mui/joy/Tabs";
-import Tab from "@mui/joy/Tab";
-import TabList from "@mui/joy/TabList";
 import Box from "@mui/joy/Box";
 import { requireAuthContext, hasRole } from "~/auth.helpers.server";
 import { createDbClient } from "~/db/client";
 import { createCfDb } from "~/db/cfast.server";
-import { compose } from "@cfast/db";
-import { posts, users, auditLogs } from "~/db/schema";
-import { eq, desc, count, and } from "drizzle-orm";
+import { compose, parseOffsetParams } from "@cfast/db";
+import type { OffsetPage } from "@cfast/db";
+import { useOffsetPagination } from "@cfast/pagination";
+import { posts, auditLogs } from "~/db/schema";
+import { eq, desc } from "drizzle-orm";
 import { nanoid } from "nanoid";
-import { Pagination } from "~/components/Pagination";
 import { ConfirmDialog } from "~/components/ConfirmDialog";
+
+type PostItem = {
+  id: string;
+  title: string;
+  slug: string;
+  published: boolean;
+  coverImageKey: string | null;
+  createdAt: Date;
+  author: { name: string } | null;
+};
 
 export async function loader({ request, context }: LoaderFunctionArgs) {
   const env = context.cloudflare.env;
@@ -28,12 +36,10 @@ export async function loader({ request, context }: LoaderFunctionArgs) {
     throw redirect("/");
   }
 
-  const db = createDbClient(env.DB);
+  const cfDb = createCfDb(env.DB, ctx);
+  const params = parseOffsetParams(request, { defaultLimit: 20, maxLimit: 50 });
   const url = new URL(request.url);
-  const page = Math.max(1, parseInt(url.searchParams.get("page") ?? "1", 10));
-  const limit = Math.min(50, Math.max(1, parseInt(url.searchParams.get("limit") ?? "20", 10)));
   const status = url.searchParams.get("status") ?? "all";
-  const offset = (page - 1) * limit;
 
   const statusCondition =
     status === "published"
@@ -42,31 +48,13 @@ export async function loader({ request, context }: LoaderFunctionArgs) {
         ? eq(posts.published, false)
         : undefined;
 
-  const postList = await db
-    .select({
-      id: posts.id,
-      title: posts.title,
-      slug: posts.slug,
-      published: posts.published,
-      coverImageKey: posts.coverImageKey,
-      createdAt: posts.createdAt,
-      authorName: users.name,
-    })
-    .from(posts)
-    .leftJoin(users, eq(posts.authorId, users.id))
-    .where(statusCondition)
-    .orderBy(desc(posts.createdAt))
-    .limit(limit)
-    .offset(offset);
+  const result = await cfDb.query(posts).paginate(params, {
+    where: statusCondition,
+    orderBy: desc(posts.createdAt),
+    with: { author: { columns: { name: true } } },
+  }).run({}) as OffsetPage<unknown>;
 
-  const totalResult = await db
-    .select({ total: count() })
-    .from(posts)
-    .where(statusCondition)
-    .get();
-  const total = totalResult?.total ?? 0;
-
-  return { posts: postList, total, page, limit, status };
+  return { ...result, status };
 }
 
 export async function action({ request, context }: ActionFunctionArgs) {
@@ -127,16 +115,13 @@ export async function action({ request, context }: ActionFunctionArgs) {
 }
 
 export default function AdminPosts() {
-  const { posts: postList, total, page, limit, status } =
-    useLoaderData<typeof loader>();
+  const { items: postList, total, totalPages, currentPage, goToPage } =
+    useOffsetPagination<PostItem>();
+  const { status } = useLoaderData() as { status: string };
   const actionData = useActionData<typeof action>();
-  const totalPages = Math.ceil(total / limit);
 
   const [deletePostId, setDeletePostId] = useState<string | null>(null);
   const [deletePostTitle, setDeletePostTitle] = useState<string>("");
-
-  const baseUrl =
-    status !== "all" ? `/admin/posts?status=${status}` : "/admin/posts";
 
   return (
     <Stack spacing={3}>
@@ -217,7 +202,7 @@ export default function AdminPosts() {
             {postList.map((post) => (
               <tr key={post.id}>
                 <td>{post.title}</td>
-                <td>{post.authorName ?? "Unknown"}</td>
+                <td>{post.author?.name ?? "Unknown"}</td>
                 <td>
                   <Chip
                     size="sm"
@@ -282,7 +267,47 @@ export default function AdminPosts() {
         </Table>
       </Box>
 
-      <Pagination currentPage={page} totalPages={totalPages} baseUrl={baseUrl} />
+      {totalPages > 1 && (
+        <Stack direction="row" spacing={1} justifyContent="center" sx={{ mt: 3 }}>
+          <Button
+            variant="outlined"
+            color="neutral"
+            size="sm"
+            disabled={currentPage <= 1}
+            onClick={() => goToPage(currentPage - 1)}
+          >
+            Previous
+          </Button>
+          {Array.from({ length: Math.min(5, totalPages) }, (_, i) => {
+            const maxVisible = 5;
+            let start = Math.max(1, currentPage - Math.floor(maxVisible / 2));
+            const end = Math.min(totalPages, start + maxVisible - 1);
+            start = Math.max(1, end - maxVisible + 1);
+            const page = start + i;
+            if (page > totalPages) return null;
+            return (
+              <Button
+                key={page}
+                variant={page === currentPage ? "solid" : "outlined"}
+                color={page === currentPage ? "primary" : "neutral"}
+                size="sm"
+                onClick={() => goToPage(page)}
+              >
+                {page}
+              </Button>
+            );
+          })}
+          <Button
+            variant="outlined"
+            color="neutral"
+            size="sm"
+            disabled={currentPage >= totalPages}
+            onClick={() => goToPage(currentPage + 1)}
+          >
+            Next
+          </Button>
+        </Stack>
+      )}
 
       <ConfirmDialog
         open={deletePostId !== null}

--- a/examples/team-blog-after/app/routes/posts.$slug.tsx
+++ b/examples/team-blog-after/app/routes/posts.$slug.tsx
@@ -1,6 +1,6 @@
 import type { LoaderFunctionArgs } from "react-router";
-import { useLoaderData, useActionData, Form, Link, useFetcher } from "react-router";
-import { useState, useEffect, useCallback, useRef } from "react";
+import { useLoaderData, useActionData, Form, Link } from "react-router";
+import { useState } from "react";
 import Container from "@mui/joy/Container";
 import Stack from "@mui/joy/Stack";
 import Typography from "@mui/joy/Typography";
@@ -12,11 +12,15 @@ import Box from "@mui/joy/Box";
 import Avatar from "@mui/joy/Avatar";
 import Divider from "@mui/joy/Divider";
 import Chip from "@mui/joy/Chip";
-import { getUser } from "~/auth.helpers.server";
+import { getAuthContext } from "~/auth.helpers.server";
 import { hasRole, hasAnyRole } from "~/permissions";
 import { createDbClient } from "~/db/client";
+import { createCfDb } from "~/db/cfast.server";
+import { parseCursorParams } from "@cfast/db";
+import type { CursorPage } from "@cfast/db";
+import { useInfiniteScroll } from "@cfast/pagination";
 import { posts, users, comments } from "~/db/schema";
-import { eq, desc, and, lt } from "drizzle-orm";
+import { eq, desc } from "drizzle-orm";
 import { Header } from "~/components/Header";
 import { CommentItem } from "~/components/CommentItem";
 import { composeActions } from "~/actions.server";
@@ -28,9 +32,17 @@ import {
   deleteComment,
 } from "~/actions/posts";
 
+type CommentType = {
+  id: string;
+  content: string;
+  createdAt: Date;
+  author: { id: string; name: string; avatarUrl: string | null };
+};
+
 export async function loader({ request, params, context }: LoaderFunctionArgs) {
   const env = context.cloudflare.env;
-  const user = await getUser(request);
+  const authCtx = await getAuthContext(request);
+  const user = authCtx.user;
   const db = createDbClient(env.DB);
 
   const slug = params.slug;
@@ -52,53 +64,25 @@ export async function loader({ request, params, context }: LoaderFunctionArgs) {
   // Get author info
   const author = await db.select().from(users).where(eq(users.id, post.authorId)).get();
 
-  // Cursor-based comments: get URL cursor param
-  const url = new URL(request.url);
-  const cursor = url.searchParams.get("cursor");
+  // Cursor-based comments using @cfast/db pagination
+  const cursorParams = parseCursorParams(request, { defaultLimit: 20 });
+  const cfDb = createCfDb(env.DB, authCtx);
 
-  let commentQuery = db
-    .select({
-      id: comments.id,
-      content: comments.content,
-      createdAt: comments.createdAt,
-      authorId: comments.authorId,
-      authorName: users.name,
-      authorAvatarUrl: users.avatarUrl,
-    })
-    .from(comments)
-    .leftJoin(users, eq(comments.authorId, users.id))
-    .where(
-      cursor
-        ? and(eq(comments.postId, post.id), lt(comments.id, cursor))
-        : eq(comments.postId, post.id)
-    )
-    .orderBy(desc(comments.createdAt))
-    .limit(21);
-
-  const rawComments = await commentQuery;
-
-  const hasMore = rawComments.length > 20;
-  const displayComments = rawComments.slice(0, 20);
-  const nextCursor = hasMore ? displayComments[displayComments.length - 1].id : null;
-
-  const formattedComments = displayComments.map((c) => ({
-    id: c.id,
-    content: c.content,
-    createdAt: c.createdAt,
-    author: {
-      id: c.authorId,
-      name: c.authorName ?? "Unknown",
-      avatarUrl: c.authorAvatarUrl ?? null,
-    },
-  }));
+  const commentResult = await cfDb.query(comments).paginate(cursorParams, {
+    where: eq(comments.postId, post.id),
+    orderBy: desc(comments.createdAt),
+    cursorColumns: [comments.id],
+    orderDirection: "desc",
+    with: { author: { columns: { id: true, name: true, avatarUrl: true } } },
+  }).run({}) as CursorPage<unknown>;
 
   return {
     post,
     author: author
       ? { id: author.id, name: author.name, avatarUrl: author.avatarUrl }
       : { id: post.authorId, name: "Unknown", avatarUrl: null },
-    comments: formattedComments,
-    nextCursor,
+    items: commentResult.items,
+    nextCursor: commentResult.nextCursor,
     user,
   };
 }
@@ -130,87 +114,15 @@ function formatDate(date: Date | string): string {
   });
 }
 
-function useInfiniteComments(
-  initialComments: Array<{
-    id: string;
-    content: string;
-    createdAt: Date;
-    author: { id: string; name: string; avatarUrl: string | null };
-  }>,
-  initialCursor: string | null,
-  slug: string
-) {
-  const [allComments, setAllComments] = useState(initialComments);
-  const [cursor, setCursor] = useState(initialCursor);
-  const [isLoadingMore, setIsLoadingMore] = useState(false);
-  const fetcher = useFetcher();
-  const loadingRef = useRef(false);
-
-  // Reset when initial data changes (e.g. after action)
-  useEffect(() => {
-    setAllComments(initialComments);
-    setCursor(initialCursor);
-  }, [initialComments, initialCursor]);
-
-  // Process fetcher data when it arrives
-  useEffect(() => {
-    if (fetcher.data && loadingRef.current) {
-      const data = fetcher.data as {
-        comments: typeof initialComments;
-        nextCursor: string | null;
-      };
-      setAllComments((prev) => [...prev, ...data.comments]);
-      setCursor(data.nextCursor);
-      setIsLoadingMore(false);
-      loadingRef.current = false;
-    }
-  }, [fetcher.data]);
-
-  const loadMore = useCallback(() => {
-    if (!cursor || isLoadingMore || loadingRef.current) return;
-    setIsLoadingMore(true);
-    loadingRef.current = true;
-    fetcher.load(`/posts/${slug}?cursor=${cursor}`);
-  }, [cursor, isLoadingMore, slug, fetcher]);
-
-  const hasMore = cursor !== null;
-
-  // Intersection observer for infinite scroll
-  const observerRef = useRef<IntersectionObserver | null>(null);
-  const sentinelRef = useCallback(
-    (node: HTMLDivElement | null) => {
-      if (observerRef.current) observerRef.current.disconnect();
-      if (!node || !hasMore) return;
-
-      observerRef.current = new IntersectionObserver(
-        (entries) => {
-          if (entries[0].isIntersecting && hasMore && !isLoadingMore) {
-            loadMore();
-          }
-        },
-        { threshold: 0.1 }
-      );
-      observerRef.current.observe(node);
-    },
-    [hasMore, isLoadingMore, loadMore]
-  );
-
-  return { allComments, hasMore, isLoadingMore, loadMore, sentinelRef };
-}
-
 export default function PostDetail() {
-  const { post, author, comments: initialComments, nextCursor, user } =
-    useLoaderData<typeof loader>();
+  const { post, author, user } = useLoaderData<typeof loader>();
   const actionData = useActionData<typeof action>() as
     | { success: boolean; action: string }
     | { error: string; action: string }
     | undefined;
 
-  const { allComments, hasMore, isLoadingMore, sentinelRef } = useInfiniteComments(
-    initialComments,
-    nextCursor,
-    post.slug
-  );
+  const { items: allComments, sentinelRef, hasMore, isLoading: isLoadingMore } =
+    useInfiniteScroll<CommentType>();
 
   const [commentContent, setCommentContent] = useState("");
 

--- a/examples/team-blog-after/package.json
+++ b/examples/team-blog-after/package.json
@@ -22,6 +22,7 @@
     "@cfast/env": "workspace:*",
     "@cfast/db": "workspace:*",
     "@cfast/email": "workspace:*",
+    "@cfast/pagination": "workspace:*",
     "@cfast/permissions": "workspace:*",
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       '@cfast/env':
         specifier: workspace:*
         version: link:../../packages/env
+      '@cfast/pagination':
+        specifier: workspace:*
+        version: link:../../packages/pagination
       '@cfast/permissions':
         specifier: workspace:*
         version: link:../../packages/permissions
@@ -409,23 +412,28 @@ importers:
         version: 5.9.3
 
   packages/pagination:
-    dependencies:
+    devDependencies:
+      '@types/react':
+        specifier: ^19.0.0
+        version: 19.2.14
       react:
-        specifier: '>=19'
+        specifier: ^19.0.0
         version: 19.2.4
       react-dom:
-        specifier: '>=19'
+        specifier: ^19.0.0
         version: 19.2.4(react@19.2.4)
       react-router:
-        specifier: '>=7'
+        specifier: ^7.6.0
         version: 7.13.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-    devDependencies:
       tsup:
         specifier: ^8
         version: 8.5.1(postcss@8.5.8)(typescript@5.9.3)
       typescript:
         specifier: ^5.7
         version: 5.9.3
+      vitest:
+        specifier: ^4.0.18
+        version: 4.0.18(@types/node@22.19.13)(jsdom@28.1.0(@noble/hashes@2.0.1))
 
   packages/permissions:
     dependencies:


### PR DESCRIPTION
## Summary
- Replace manual offset pagination in `admin.posts.tsx` with `parseOffsetParams` + `cfDb.query().paginate()` (server) and `useOffsetPagination` hook (client)
- Replace manual cursor-based comment loading in `posts.$slug.tsx` with `parseCursorParams` + `cfDb.query().paginate()` (server) and `useInfiniteScroll` hook (client), removing the custom `useInfiniteComments` function
- Add `@cfast/pagination` as a workspace dependency to the example app

## Test plan
- [ ] Verify admin posts list loads with correct pagination controls
- [ ] Verify page navigation works (clicking page numbers, previous/next)
- [ ] Verify status filtering (all/published/draft) works with pagination
- [ ] Verify post detail page loads comments correctly
- [ ] Verify infinite scroll loads more comments when scrolling down
- [ ] Verify comment posting still works and refreshes the list

🤖 Generated with [Claude Code](https://claude.com/claude-code)