### PR TITLE
feat(ui): PR 1 — permission primitives

### DIFF
--- a/packages/ui/src/client.ts
+++ b/packages/ui/src/client.ts
@@ -1,5 +1,11 @@
 // Client-only exports — hooks that depend on browser APIs / react-router
-// Components will be added in subsequent PRs
 
-// Re-export plugin API for client usage
+// Plugin API
 export { createUIPlugin, UIPluginProvider, useUIPlugin, useComponent } from "./plugin.js";
+
+// Hooks
+export { useActionStatus } from "./hooks/use-action-status.js";
+
+// Headless components
+export { PermissionGate } from "./components/permission-gate.js";
+export { ActionButton } from "./components/action-button.js";

--- a/packages/ui/src/components/action-button.test.tsx
+++ b/packages/ui/src/components/action-button.test.tsx
@@ -1,0 +1,167 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, cleanup, fireEvent } from "@testing-library/react";
+import { createElement } from "react";
+import { ActionButton } from "./action-button.js";
+import { createMockDescriptor } from "../__tests__/helpers.js";
+
+afterEach(cleanup);
+
+// Mock useActionStatus
+vi.mock("../hooks/use-action-status.js", () => ({
+  useActionStatus: vi.fn(),
+}));
+
+import { useActionStatus } from "../hooks/use-action-status.js";
+const mockUseActionStatus = vi.mocked(useActionStatus);
+
+describe("ActionButton", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders button and calls submit on click when permitted", () => {
+    const submitFn = vi.fn();
+    mockUseActionStatus.mockReturnValue({
+      permitted: true,
+      invisible: false,
+      reason: null,
+      submit: submitFn,
+      pending: false,
+      data: undefined,
+      error: undefined,
+    });
+
+    const descriptor = createMockDescriptor(["deletePost"]);
+    render(
+      createElement(ActionButton, {
+        action: descriptor,
+        children: "Delete",
+      }),
+    );
+
+    const button = screen.getByRole("button");
+    expect(button.textContent).toBe("Delete");
+
+    fireEvent.click(button);
+    expect(submitFn).toHaveBeenCalled();
+  });
+
+  it("hides button when invisible", () => {
+    mockUseActionStatus.mockReturnValue({
+      permitted: false,
+      invisible: true,
+      reason: null,
+      submit: vi.fn(),
+      pending: false,
+      data: undefined,
+      error: undefined,
+    });
+
+    const descriptor = createMockDescriptor(["deletePost"]);
+    const { container } = render(
+      createElement(ActionButton, {
+        action: descriptor,
+        children: "Delete",
+      }),
+    );
+
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("hides button when forbidden and whenForbidden=hide", () => {
+    mockUseActionStatus.mockReturnValue({
+      permitted: false,
+      invisible: false,
+      reason: "No permission",
+      submit: vi.fn(),
+      pending: false,
+      data: undefined,
+      error: undefined,
+    });
+
+    const descriptor = createMockDescriptor(["deletePost"]);
+    const { container } = render(
+      createElement(ActionButton, {
+        action: descriptor,
+        whenForbidden: "hide",
+        children: "Delete",
+      }),
+    );
+
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("disables button when forbidden and whenForbidden=disable (default)", () => {
+    mockUseActionStatus.mockReturnValue({
+      permitted: false,
+      invisible: false,
+      reason: "No permission",
+      submit: vi.fn(),
+      pending: false,
+      data: undefined,
+      error: undefined,
+    });
+
+    const descriptor = createMockDescriptor(["deletePost"]);
+    render(
+      createElement(ActionButton, {
+        action: descriptor,
+        children: "Delete",
+      }),
+    );
+
+    const button = screen.getByRole("button");
+    expect((button as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it("shows loading state when pending", () => {
+    mockUseActionStatus.mockReturnValue({
+      permitted: true,
+      invisible: false,
+      reason: null,
+      submit: vi.fn(),
+      pending: true,
+      data: undefined,
+      error: undefined,
+    });
+
+    const descriptor = createMockDescriptor(["deletePost"]);
+    render(
+      createElement(ActionButton, {
+        action: descriptor,
+        children: "Delete",
+      }),
+    );
+
+    // Headless default button shows "Loading..." when loading
+    expect(screen.getByRole("button").textContent).toBe("Loading...");
+  });
+
+  it("shows button when forbidden and whenForbidden=show", () => {
+    const submitFn = vi.fn();
+    mockUseActionStatus.mockReturnValue({
+      permitted: false,
+      invisible: false,
+      reason: "No permission",
+      submit: submitFn,
+      pending: false,
+      data: undefined,
+      error: undefined,
+    });
+
+    const descriptor = createMockDescriptor(["deletePost"]);
+    render(
+      createElement(ActionButton, {
+        action: descriptor,
+        whenForbidden: "show",
+        children: "Delete",
+      }),
+    );
+
+    const button = screen.getByRole("button");
+    expect((button as HTMLButtonElement).disabled).toBe(false);
+
+    fireEvent.click(button);
+    expect(submitFn).toHaveBeenCalled();
+  });
+});

--- a/packages/ui/src/components/action-button.tsx
+++ b/packages/ui/src/components/action-button.tsx
@@ -1,0 +1,52 @@
+import { createElement } from "react";
+import { useActionStatus } from "../hooks/use-action-status.js";
+import { useComponent } from "../plugin.js";
+import type { ActionButtonProps } from "../types.js";
+
+/**
+ * Permission-aware button that submits an action.
+ *
+ * - whenForbidden="hide": hidden when not permitted
+ * - whenForbidden="disable": shown but disabled when not permitted
+ * - whenForbidden="show": shown and clickable regardless of permission
+ *
+ * Supports a `confirmation` prop that, when set, will be used by
+ * the confirm system (wired in the Feedback PR).
+ */
+export function ActionButton({
+  action,
+  actionName,
+  input,
+  children,
+  whenForbidden = "disable",
+  confirmation: _confirmation,
+  variant,
+  color,
+  size,
+  startDecorator,
+}: ActionButtonProps) {
+  const status = useActionStatus(action, actionName, input);
+  const Button = useComponent("button");
+
+  // Handle visibility
+  if (status.invisible) {
+    return null;
+  }
+
+  if (!status.permitted && whenForbidden === "hide") {
+    return null;
+  }
+
+  const disabled = !status.permitted && whenForbidden === "disable";
+
+  return createElement(Button, {
+    children,
+    onClick: () => status.submit(),
+    disabled,
+    loading: status.pending,
+    variant,
+    color,
+    size,
+    startDecorator,
+  });
+}

--- a/packages/ui/src/components/permission-gate.test.tsx
+++ b/packages/ui/src/components/permission-gate.test.tsx
@@ -1,0 +1,111 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import { createElement } from "react";
+import { PermissionGate } from "./permission-gate.js";
+import { createMockDescriptor } from "../__tests__/helpers.js";
+
+afterEach(cleanup);
+
+// Mock useActionStatus
+vi.mock("../hooks/use-action-status.js", () => ({
+  useActionStatus: vi.fn(),
+}));
+
+import { useActionStatus } from "../hooks/use-action-status.js";
+const mockUseActionStatus = vi.mocked(useActionStatus);
+
+describe("PermissionGate", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders children when permitted", () => {
+    mockUseActionStatus.mockReturnValue({
+      permitted: true,
+      invisible: false,
+      reason: null,
+      submit: vi.fn(),
+      pending: false,
+      data: undefined,
+      error: undefined,
+    });
+
+    const descriptor = createMockDescriptor(["editPost"]);
+    render(
+      createElement(PermissionGate, {
+        action: descriptor,
+        children: createElement("div", { "data-testid": "content" }, "Visible"),
+      }),
+    );
+
+    expect(screen.getByTestId("content").textContent).toBe("Visible");
+  });
+
+  it("renders nothing when invisible", () => {
+    mockUseActionStatus.mockReturnValue({
+      permitted: false,
+      invisible: true,
+      reason: null,
+      submit: vi.fn(),
+      pending: false,
+      data: undefined,
+      error: undefined,
+    });
+
+    const descriptor = createMockDescriptor(["editPost"]);
+    const { container } = render(
+      createElement(PermissionGate, {
+        action: descriptor,
+        children: createElement("div", null, "Should not appear"),
+      }),
+    );
+
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("renders fallback when forbidden (not permitted, not invisible)", () => {
+    mockUseActionStatus.mockReturnValue({
+      permitted: false,
+      invisible: false,
+      reason: "No permission",
+      submit: vi.fn(),
+      pending: false,
+      data: undefined,
+      error: undefined,
+    });
+
+    const descriptor = createMockDescriptor(["editPost"]);
+    render(
+      createElement(PermissionGate, {
+        action: descriptor,
+        children: createElement("div", null, "Hidden"),
+        fallback: createElement("div", { "data-testid": "fallback" }, "Read only"),
+      }),
+    );
+
+    expect(screen.queryByText("Hidden")).toBeNull();
+    expect(screen.getByTestId("fallback").textContent).toBe("Read only");
+  });
+
+  it("renders nothing when forbidden and no fallback provided", () => {
+    mockUseActionStatus.mockReturnValue({
+      permitted: false,
+      invisible: false,
+      reason: "No permission",
+      submit: vi.fn(),
+      pending: false,
+      data: undefined,
+      error: undefined,
+    });
+
+    const descriptor = createMockDescriptor(["editPost"]);
+    const { container } = render(
+      createElement(PermissionGate, {
+        action: descriptor,
+        children: createElement("div", null, "Hidden"),
+      }),
+    );
+
+    expect(container.innerHTML).toBe("");
+  });
+});

--- a/packages/ui/src/components/permission-gate.tsx
+++ b/packages/ui/src/components/permission-gate.tsx
@@ -1,0 +1,30 @@
+import { createElement, Fragment } from "react";
+import { useActionStatus } from "../hooks/use-action-status.js";
+import type { PermissionGateProps } from "../types.js";
+
+/**
+ * Conditionally renders children based on action permission status.
+ *
+ * - When permitted: renders children
+ * - When forbidden (not permitted, not invisible): renders fallback
+ * - When invisible: renders nothing
+ */
+export function PermissionGate({
+  action,
+  actionName,
+  input,
+  children,
+  fallback,
+}: PermissionGateProps) {
+  const status = useActionStatus(action, actionName, input);
+
+  if (status.invisible) {
+    return null;
+  }
+
+  if (!status.permitted) {
+    return fallback ? createElement(Fragment, null, fallback) : null;
+  }
+
+  return createElement(Fragment, null, children);
+}

--- a/packages/ui/src/hooks/use-action-status.test.ts
+++ b/packages/ui/src/hooks/use-action-status.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { useActionStatus } from "./use-action-status.js";
+import { createMockDescriptor } from "../__tests__/helpers.js";
+
+// Mock @cfast/actions/client
+vi.mock("@cfast/actions/client", () => ({
+  useActions: vi.fn(),
+}));
+
+import { useActions } from "@cfast/actions/client";
+const mockUseActions = vi.mocked(useActions);
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("useActionStatus", () => {
+  it("returns status for the first action when no actionName specified", () => {
+    const descriptor = createMockDescriptor(["deletePost"]);
+    mockUseActions.mockReturnValue({
+      deletePost: () => ({
+        permitted: true,
+        invisible: false,
+        reason: null,
+        submit: vi.fn(),
+        pending: false,
+        data: undefined,
+        error: undefined,
+      }),
+    });
+
+    const { result } = renderHook(() => useActionStatus(descriptor));
+
+    expect(result.current.permitted).toBe(true);
+    expect(result.current.invisible).toBe(false);
+    expect(result.current.pending).toBe(false);
+  });
+
+  it("returns status for a named action", () => {
+    const descriptor = createMockDescriptor(["createPost", "deletePost"]);
+    const submitFn = vi.fn();
+    mockUseActions.mockReturnValue({
+      createPost: () => ({
+        permitted: true,
+        invisible: false,
+        reason: null,
+        submit: vi.fn(),
+        pending: false,
+        data: undefined,
+        error: undefined,
+      }),
+      deletePost: () => ({
+        permitted: false,
+        invisible: false,
+        reason: "No permission",
+        submit: submitFn,
+        pending: false,
+        data: undefined,
+        error: undefined,
+      }),
+    });
+
+    const { result } = renderHook(() =>
+      useActionStatus(descriptor, "deletePost"),
+    );
+
+    expect(result.current.permitted).toBe(false);
+    expect(result.current.reason).toBe("No permission");
+  });
+
+  it("returns invisible status when action not found", () => {
+    const descriptor = createMockDescriptor(["createPost"]);
+    mockUseActions.mockReturnValue({
+      createPost: () => ({
+        permitted: true,
+        invisible: false,
+        reason: null,
+        submit: vi.fn(),
+        pending: false,
+        data: undefined,
+        error: undefined,
+      }),
+    });
+
+    const { result } = renderHook(() =>
+      useActionStatus(descriptor, "nonexistent"),
+    );
+
+    expect(result.current.permitted).toBe(false);
+    expect(result.current.invisible).toBe(true);
+  });
+
+  it("passes input to the action function", () => {
+    const descriptor = createMockDescriptor(["deletePost"]);
+    const actionFn = vi.fn().mockReturnValue({
+      permitted: true,
+      invisible: false,
+      reason: null,
+      submit: vi.fn(),
+      pending: false,
+      data: undefined,
+      error: undefined,
+    });
+    mockUseActions.mockReturnValue({ deletePost: actionFn });
+
+    renderHook(() =>
+      useActionStatus(descriptor, "deletePost", { postId: "123" }),
+    );
+
+    expect(actionFn).toHaveBeenCalledWith({ postId: "123" });
+  });
+
+  it("exposes pending state from the action", () => {
+    const descriptor = createMockDescriptor(["savePost"]);
+    mockUseActions.mockReturnValue({
+      savePost: () => ({
+        permitted: true,
+        invisible: false,
+        reason: null,
+        submit: vi.fn(),
+        pending: true,
+        data: undefined,
+        error: undefined,
+      }),
+    });
+
+    const { result } = renderHook(() => useActionStatus(descriptor));
+
+    expect(result.current.pending).toBe(true);
+  });
+});

--- a/packages/ui/src/hooks/use-action-status.ts
+++ b/packages/ui/src/hooks/use-action-status.ts
@@ -1,0 +1,43 @@
+import { useActions } from "@cfast/actions/client";
+import type { ClientDescriptor, Serializable } from "@cfast/actions";
+import type { ActionStatusResult } from "../types.js";
+
+/**
+ * Returns the permission status and submit function for a single action
+ * from a composed action descriptor.
+ *
+ * If `actionName` is omitted, uses the first (or only) action in the descriptor.
+ */
+export function useActionStatus(
+  descriptor: ClientDescriptor,
+  actionName?: string,
+  input?: Record<string, Serializable>,
+): ActionStatusResult {
+  const actions = useActions(descriptor);
+  const name = actionName ?? descriptor.actionNames[0];
+  const actionFn = actions[name];
+
+  if (!actionFn) {
+    return {
+      permitted: false,
+      invisible: true,
+      reason: `Action "${name}" not found in descriptor`,
+      submit: () => {},
+      pending: false,
+      data: undefined,
+      error: undefined,
+    };
+  }
+
+  const result = actionFn(input as Serializable | undefined);
+
+  return {
+    permitted: result.permitted,
+    invisible: result.invisible,
+    reason: result.reason,
+    submit: result.submit,
+    pending: result.pending,
+    data: result.data,
+    error: result.error,
+  };
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,6 +1,13 @@
 // Plugin API
 export { createUIPlugin, UIPluginProvider, useUIPlugin, useComponent } from "./plugin.js";
 
+// Hooks
+export { useActionStatus } from "./hooks/use-action-status.js";
+
+// Headless components
+export { PermissionGate } from "./components/permission-gate.js";
+export { ActionButton } from "./components/action-button.js";
+
 // Types
 export type {
   UIPlugin,

--- a/packages/ui/src/joy.ts
+++ b/packages/ui/src/joy.ts
@@ -1,3 +1,2 @@
 // Joy UI plugin — styled implementations
-// Components will be added in subsequent PRs
-export {};
+export { ActionButton } from "./joy/action-button.js";

--- a/packages/ui/src/joy/action-button.tsx
+++ b/packages/ui/src/joy/action-button.tsx
@@ -1,0 +1,56 @@
+import { createElement, type ReactElement } from "react";
+import JoyButton from "@mui/joy/Button";
+import JoyTooltip from "@mui/joy/Tooltip";
+import { useActionStatus } from "../hooks/use-action-status.js";
+import type { ActionButtonProps } from "../types.js";
+
+/**
+ * Joy UI styled ActionButton.
+ * Uses MUI Joy Button with tooltip for disabled state reason.
+ */
+export function ActionButton({
+  action,
+  actionName,
+  input,
+  children,
+  whenForbidden = "disable",
+  confirmation: _confirmation,
+  variant = "solid",
+  color = "primary",
+  size = "md",
+  startDecorator,
+}: ActionButtonProps): ReactElement | null {
+  const status = useActionStatus(action, actionName, input);
+
+  if (status.invisible) {
+    return null;
+  }
+
+  if (!status.permitted && whenForbidden === "hide") {
+    return null;
+  }
+
+  const disabled = !status.permitted && whenForbidden === "disable";
+
+  const button = createElement(JoyButton, {
+    onClick: () => status.submit(),
+    disabled,
+    loading: status.pending,
+    variant,
+    color,
+    size,
+    startDecorator,
+    children,
+  });
+
+  // Wrap in tooltip if disabled with a reason
+  if (disabled && status.reason) {
+    const wrapper = createElement("span", null, button);
+    return createElement(JoyTooltip, {
+      title: status.reason,
+      children: wrapper,
+    });
+  }
+
+  return button;
+}

--- a/packages/ui/src/types.ts
+++ b/packages/ui/src/types.ts
@@ -1,5 +1,5 @@
 import type { ComponentType, ReactNode } from "react";
-import type { ClientDescriptor, ActionPermissionStatus } from "@cfast/actions";
+import type { ClientDescriptor, ActionPermissionStatus, Serializable } from "@cfast/actions";
 
 // --- Plugin System ---
 
@@ -379,7 +379,7 @@ export type BulkAction = {
 export type ActionButtonProps = {
   action: ClientDescriptor;
   actionName?: string;
-  input?: Record<string, unknown>;
+  input?: Record<string, Serializable>;
   children: ReactNode;
   whenForbidden?: WhenForbidden;
   confirmation?: string | ConfirmOptions;
@@ -394,7 +394,7 @@ export type ActionButtonProps = {
 export type PermissionGateProps = {
   action: ClientDescriptor;
   actionName?: string;
-  input?: Record<string, unknown>;
+  input?: Record<string, Serializable>;
   children: ReactNode;
   fallback?: ReactNode;
 };


### PR DESCRIPTION
## Summary
- `useActionStatus(descriptor, actionName?, input?)` — single-action permission + submit wrapper
- `PermissionGate` — conditional rendering based on action permissions
- `ActionButton` — permission-aware button with `whenForbidden` modes (hide/disable/show)
- Joy UI `ActionButton` with tooltip for disabled reason

## Test plan
- [x] `pnpm test` — 15 new tests pass (22 total)
- [x] `pnpm typecheck` — no errors
- [x] `pnpm build` — clean

> Part 2 of 10 in the `@cfast/ui` stack. Depends on PR 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)