### PR TITLE
feat(ui): PR 2 — feedback (confirm, toasts, form status)

### DIFF
--- a/packages/ui/src/client.ts
+++ b/packages/ui/src/client.ts
@@ -5,7 +5,12 @@ export { createUIPlugin, UIPluginProvider, useUIPlugin, useComponent } from "./p
 
 // Hooks
 export { useActionStatus } from "./hooks/use-action-status.js";
+export { useConfirm } from "./hooks/use-confirm.js";
+export { useToast } from "./hooks/use-toast.js";
+export { useActionToast } from "./hooks/use-action-toast.js";
 
 // Headless components
 export { PermissionGate } from "./components/permission-gate.js";
 export { ActionButton } from "./components/action-button.js";
+export { ConfirmProvider } from "./components/confirm-provider.js";
+export { FormStatus } from "./components/form-status.js";

--- a/packages/ui/src/components/confirm-provider.test.tsx
+++ b/packages/ui/src/components/confirm-provider.test.tsx
@@ -1,0 +1,86 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { render, screen, cleanup, fireEvent, act } from "@testing-library/react";
+import { createElement, useState } from "react";
+import { ConfirmProvider } from "./confirm-provider.js";
+import { useConfirm } from "../hooks/use-confirm.js";
+
+afterEach(cleanup);
+
+function TestConsumer() {
+  const confirm = useConfirm();
+  const [result, setResult] = useState<string>("pending");
+
+  return createElement("div", null,
+    createElement("button", {
+      "data-testid": "trigger",
+      onClick: async () => {
+        const confirmed = await confirm({
+          title: "Delete item?",
+          description: "This cannot be undone.",
+          confirmLabel: "Yes, delete",
+          cancelLabel: "No",
+          variant: "danger",
+        });
+        setResult(confirmed ? "confirmed" : "cancelled");
+      },
+    }, "Open dialog"),
+    createElement("span", { "data-testid": "result" }, result),
+  );
+}
+
+describe("ConfirmProvider", () => {
+  it("provides useConfirm context and renders dialog on trigger", async () => {
+    render(
+      createElement(ConfirmProvider, {
+        children: createElement(TestConsumer),
+      }),
+    );
+
+    expect(screen.getByTestId("result").textContent).toBe("pending");
+
+    // Open dialog
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("trigger"));
+    });
+
+    // Dialog should appear (headless default uses <dialog>)
+    expect(screen.getByText("Delete item?")).toBeTruthy();
+    expect(screen.getByText("This cannot be undone.")).toBeTruthy();
+  });
+
+  it("resolves true when confirmed", async () => {
+    render(
+      createElement(ConfirmProvider, {
+        children: createElement(TestConsumer),
+      }),
+    );
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("trigger"));
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByText("Yes, delete"));
+    });
+
+    expect(screen.getByTestId("result").textContent).toBe("confirmed");
+  });
+
+  it("resolves false when cancelled", async () => {
+    render(
+      createElement(ConfirmProvider, {
+        children: createElement(TestConsumer),
+      }),
+    );
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("trigger"));
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByText("No"));
+    });
+
+    expect(screen.getByTestId("result").textContent).toBe("cancelled");
+  });
+});

--- a/packages/ui/src/components/confirm-provider.tsx
+++ b/packages/ui/src/components/confirm-provider.tsx
@@ -1,0 +1,56 @@
+import { createElement, useState, useCallback, useRef } from "react";
+import type { ReactNode } from "react";
+import { ConfirmContext } from "../hooks/use-confirm.js";
+import { useComponent } from "../plugin.js";
+import type { ConfirmOptions } from "../types.js";
+
+type ConfirmState = ConfirmOptions & {
+  resolve: (value: boolean) => void;
+};
+
+/**
+ * Provides the `useConfirm()` context and renders the confirm dialog.
+ * Uses the plugin's `confirmDialog` slot for rendering.
+ */
+export function ConfirmProvider({ children }: { children: ReactNode }) {
+  const [state, setState] = useState<ConfirmState | null>(null);
+  const ConfirmDialog = useComponent("confirmDialog");
+  const resolveRef = useRef<((value: boolean) => void) | null>(null);
+
+  const confirm = useCallback((options: ConfirmOptions): Promise<boolean> => {
+    return new Promise<boolean>((resolve) => {
+      resolveRef.current = resolve;
+      setState({ ...options, resolve });
+    });
+  }, []);
+
+  const handleClose = useCallback(() => {
+    resolveRef.current?.(false);
+    resolveRef.current = null;
+    setState(null);
+  }, []);
+
+  const handleConfirm = useCallback(() => {
+    resolveRef.current?.(true);
+    resolveRef.current = null;
+    setState(null);
+  }, []);
+
+  return createElement(
+    ConfirmContext.Provider,
+    { value: { confirm } },
+    children,
+    state
+      ? createElement(ConfirmDialog, {
+          open: true,
+          onClose: handleClose,
+          onConfirm: handleConfirm,
+          title: state.title,
+          description: state.description,
+          confirmLabel: state.confirmLabel,
+          cancelLabel: state.cancelLabel,
+          variant: state.variant,
+        })
+      : null,
+  );
+}

--- a/packages/ui/src/components/form-status.test.tsx
+++ b/packages/ui/src/components/form-status.test.tsx
@@ -1,0 +1,59 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import { createElement } from "react";
+import { FormStatus } from "./form-status.js";
+
+afterEach(cleanup);
+
+describe("FormStatus", () => {
+  it("renders nothing when data is null", () => {
+    const { container } = render(
+      createElement(FormStatus, { data: null }),
+    );
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("renders success alert", () => {
+    render(
+      createElement(FormStatus, {
+        data: { success: "Saved successfully" },
+      }),
+    );
+    expect(screen.getByText("Saved successfully")).toBeTruthy();
+  });
+
+  it("renders error alert", () => {
+    render(
+      createElement(FormStatus, {
+        data: { error: "Something went wrong" },
+      }),
+    );
+    expect(screen.getByText("Something went wrong")).toBeTruthy();
+  });
+
+  it("renders field errors as a list", () => {
+    render(
+      createElement(FormStatus, {
+        data: {
+          fieldErrors: {
+            title: ["Required"],
+            email: ["Invalid format", "Already taken"],
+          },
+        },
+      }),
+    );
+    expect(screen.getByText("title: Required")).toBeTruthy();
+    expect(screen.getByText("email: Invalid format")).toBeTruthy();
+    expect(screen.getByText("email: Already taken")).toBeTruthy();
+  });
+
+  it("renders both success and error when both present", () => {
+    render(
+      createElement(FormStatus, {
+        data: { success: "Saved", error: "But with warnings" },
+      }),
+    );
+    expect(screen.getByText("Saved")).toBeTruthy();
+    expect(screen.getByText("But with warnings")).toBeTruthy();
+  });
+});

--- a/packages/ui/src/components/form-status.tsx
+++ b/packages/ui/src/components/form-status.tsx
@@ -1,0 +1,53 @@
+import { createElement, type ReactNode } from "react";
+import { useComponent } from "../plugin.js";
+import type { FormStatusProps } from "../types.js";
+
+/**
+ * Displays action result feedback (success/error messages) using the
+ * plugin's `alert` slot.
+ */
+export function FormStatus({ data }: FormStatusProps) {
+  const Alert = useComponent("alert");
+
+  if (!data) return null;
+
+  const elements: ReactNode[] = [];
+
+  if (data.success) {
+    elements.push(
+      createElement(Alert, { key: "success", color: "success", children: data.success }),
+    );
+  }
+
+  if (data.error) {
+    elements.push(
+      createElement(Alert, { key: "error", color: "danger", children: data.error }),
+    );
+  }
+
+  if (data.fieldErrors) {
+    const errorMessages = Object.entries(data.fieldErrors)
+      .flatMap(([field, errors]) =>
+        errors.map((err) => `${field}: ${err}`),
+      );
+    if (errorMessages.length > 0) {
+      elements.push(
+        createElement(Alert, {
+          key: "field-errors",
+          color: "danger",
+          children: createElement(
+            "ul",
+            { style: { margin: 0, paddingLeft: "16px" } },
+            ...errorMessages.map((msg, i) =>
+              createElement("li", { key: i }, msg),
+            ),
+          ),
+        }),
+      );
+    }
+  }
+
+  if (elements.length === 0) return null;
+
+  return createElement("div", { style: { display: "flex", flexDirection: "column" as const, gap: "8px" } }, ...elements);
+}

--- a/packages/ui/src/hooks/use-action-toast.test.ts
+++ b/packages/ui/src/hooks/use-action-toast.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { createElement } from "react";
+import { useActionToast } from "./use-action-toast.js";
+import { ToastContext } from "./use-toast.js";
+import { createMockDescriptor } from "../__tests__/helpers.js";
+
+// Mock @cfast/actions/client
+vi.mock("@cfast/actions/client", () => ({
+  useActions: vi.fn(),
+}));
+
+import { useActions } from "@cfast/actions/client";
+const mockUseActions = vi.mocked(useActions);
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("useActionToast", () => {
+  it("shows success toast when action data appears", () => {
+    const mockShow = vi.fn();
+    const descriptor = createMockDescriptor(["deletePost"]);
+
+    mockUseActions.mockReturnValue({
+      deletePost: () => ({
+        permitted: true,
+        invisible: false,
+        reason: null,
+        submit: vi.fn(),
+        pending: false,
+        data: { deleted: true },
+        error: undefined,
+      }),
+    });
+
+    const wrapper = ({ children }: { children: React.ReactNode }) =>
+      createElement(ToastContext.Provider, {
+        value: { show: mockShow },
+        children,
+      });
+
+    renderHook(
+      () =>
+        useActionToast(descriptor, {
+          deletePost: { success: "Post deleted" },
+        }),
+      { wrapper },
+    );
+
+    expect(mockShow).toHaveBeenCalledWith({
+      message: "Post deleted",
+      type: "success",
+      description: undefined,
+    });
+  });
+});

--- a/packages/ui/src/hooks/use-action-toast.ts
+++ b/packages/ui/src/hooks/use-action-toast.ts
@@ -1,0 +1,53 @@
+import { useEffect, useRef } from "react";
+import { useActions } from "@cfast/actions/client";
+import type { ClientDescriptor } from "@cfast/actions";
+import { useToast } from "./use-toast.js";
+
+type ActionToastConfig = Record<
+  string,
+  { success?: string; error?: string }
+>;
+
+/**
+ * Auto-shows toasts when action results come back.
+ *
+ * ```ts
+ * useActionToast(composed.client, {
+ *   deletePost: { success: "Post deleted", error: "Failed to delete" },
+ *   publishPost: { success: "Post published" },
+ * });
+ * ```
+ */
+export function useActionToast(
+  descriptor: ClientDescriptor,
+  config: ActionToastConfig,
+): void {
+  const actions = useActions(descriptor);
+  const toast = useToast();
+  const prevDataRef = useRef<Record<string, unknown>>({});
+
+  useEffect(() => {
+    for (const [name, cfg] of Object.entries(config)) {
+      const actionFn = actions[name];
+      if (!actionFn) continue;
+
+      const result = actionFn();
+      const prevData = prevDataRef.current[name];
+
+      // Only toast when data changes (new result)
+      if (result.data !== undefined && result.data !== prevData) {
+        prevDataRef.current[name] = result.data;
+        if (cfg.success) {
+          toast.success(cfg.success);
+        }
+      }
+
+      if (result.error !== undefined && result.error !== prevData) {
+        prevDataRef.current[name] = result.error;
+        if (cfg.error) {
+          toast.error(cfg.error);
+        }
+      }
+    }
+  });
+}

--- a/packages/ui/src/hooks/use-confirm.test.ts
+++ b/packages/ui/src/hooks/use-confirm.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect, vi } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { createElement } from "react";
+import { useConfirm, ConfirmContext } from "./use-confirm.js";
+import type { ConfirmOptions } from "../types.js";
+
+describe("useConfirm", () => {
+  it("throws when used outside ConfirmProvider", () => {
+    expect(() => {
+      renderHook(() => useConfirm());
+    }).toThrow("useConfirm must be used within a <ConfirmProvider>");
+  });
+
+  it("calls confirm from context and resolves", async () => {
+    const mockConfirm = vi.fn().mockResolvedValue(true);
+
+    const wrapper = ({ children }: { children: React.ReactNode }) =>
+      createElement(ConfirmContext.Provider, {
+        value: { confirm: mockConfirm },
+        children,
+      });
+
+    const { result } = renderHook(() => useConfirm(), { wrapper });
+
+    let resolved: boolean | undefined;
+    await act(async () => {
+      resolved = await result.current({ title: "Delete?" });
+    });
+
+    expect(mockConfirm).toHaveBeenCalledWith({ title: "Delete?" } satisfies ConfirmOptions);
+    expect(resolved).toBe(true);
+  });
+});

--- a/packages/ui/src/hooks/use-confirm.ts
+++ b/packages/ui/src/hooks/use-confirm.ts
@@ -1,0 +1,27 @@
+import { createContext, useContext, useCallback } from "react";
+import type { ConfirmOptions } from "../types.js";
+
+export type ConfirmFn = (options: ConfirmOptions) => Promise<boolean>;
+
+type ConfirmContextValue = {
+  confirm: ConfirmFn;
+};
+
+export const ConfirmContext = createContext<ConfirmContextValue | null>(null);
+
+/**
+ * Returns an imperative `confirm(options)` function that resolves to
+ * `true` (confirmed) or `false` (cancelled).
+ *
+ * Must be used within a `ConfirmProvider`.
+ */
+export function useConfirm(): ConfirmFn {
+  const ctx = useContext(ConfirmContext);
+  if (!ctx) {
+    throw new Error("useConfirm must be used within a <ConfirmProvider>");
+  }
+  return useCallback(
+    (options: ConfirmOptions) => ctx.confirm(options),
+    [ctx],
+  );
+}

--- a/packages/ui/src/hooks/use-toast.test.ts
+++ b/packages/ui/src/hooks/use-toast.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { createElement } from "react";
+import { useToast, ToastContext } from "./use-toast.js";
+
+describe("useToast", () => {
+  it("throws when used outside ToastProvider", () => {
+    expect(() => {
+      renderHook(() => useToast());
+    }).toThrow("useToast must be used within a <ToastProvider>");
+  });
+
+  it("calls show with correct options for each method", () => {
+    const mockShow = vi.fn();
+
+    const wrapper = ({ children }: { children: React.ReactNode }) =>
+      createElement(ToastContext.Provider, {
+        value: { show: mockShow },
+        children,
+      });
+
+    const { result } = renderHook(() => useToast(), { wrapper });
+
+    act(() => {
+      result.current.success("Done!");
+    });
+    expect(mockShow).toHaveBeenCalledWith({
+      message: "Done!",
+      type: "success",
+      description: undefined,
+    });
+
+    mockShow.mockClear();
+
+    act(() => {
+      result.current.error("Failed", "Details here");
+    });
+    expect(mockShow).toHaveBeenCalledWith({
+      message: "Failed",
+      type: "error",
+      description: "Details here",
+    });
+  });
+});

--- a/packages/ui/src/hooks/use-toast.ts
+++ b/packages/ui/src/hooks/use-toast.ts
@@ -1,0 +1,51 @@
+import { createContext, useContext, useCallback } from "react";
+import type { ToastApi, ToastOptions } from "../types.js";
+
+type ToastContextValue = {
+  show: (options: ToastOptions) => void;
+};
+
+export const ToastContext = createContext<ToastContextValue | null>(null);
+
+/**
+ * Returns an imperative toast API.
+ *
+ * Must be used within a `ToastProvider`.
+ */
+export function useToast(): ToastApi {
+  const ctx = useContext(ToastContext);
+  if (!ctx) {
+    throw new Error("useToast must be used within a <ToastProvider>");
+  }
+
+  const show = useCallback(
+    (options: ToastOptions) => ctx.show(options),
+    [ctx],
+  );
+
+  const success = useCallback(
+    (message: string, description?: string) =>
+      ctx.show({ message, type: "success", description }),
+    [ctx],
+  );
+
+  const error = useCallback(
+    (message: string, description?: string) =>
+      ctx.show({ message, type: "error", description }),
+    [ctx],
+  );
+
+  const info = useCallback(
+    (message: string, description?: string) =>
+      ctx.show({ message, type: "info", description }),
+    [ctx],
+  );
+
+  const warning = useCallback(
+    (message: string, description?: string) =>
+      ctx.show({ message, type: "warning", description }),
+    [ctx],
+  );
+
+  return { show, success, error, info, warning };
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -3,10 +3,15 @@ export { createUIPlugin, UIPluginProvider, useUIPlugin, useComponent } from "./p
 
 // Hooks
 export { useActionStatus } from "./hooks/use-action-status.js";
+export { useConfirm } from "./hooks/use-confirm.js";
+export { useToast } from "./hooks/use-toast.js";
+export { useActionToast } from "./hooks/use-action-toast.js";
 
 // Headless components
 export { PermissionGate } from "./components/permission-gate.js";
 export { ActionButton } from "./components/action-button.js";
+export { ConfirmProvider } from "./components/confirm-provider.js";
+export { FormStatus } from "./components/form-status.js";
 
 // Types
 export type {

--- a/packages/ui/src/joy.ts
+++ b/packages/ui/src/joy.ts
@@ -1,2 +1,7 @@
 // Joy UI plugin — styled implementations
+
+// Actions & feedback
 export { ActionButton } from "./joy/action-button.js";
+export { ConfirmDialog } from "./joy/confirm-dialog.js";
+export { ToastProvider } from "./joy/toast-provider.js";
+export { FormStatus } from "./joy/form-status.js";

--- a/packages/ui/src/joy/confirm-dialog.tsx
+++ b/packages/ui/src/joy/confirm-dialog.tsx
@@ -1,0 +1,43 @@
+import { createElement, type ReactElement } from "react";
+import Modal from "@mui/joy/Modal";
+import ModalDialog from "@mui/joy/ModalDialog";
+import Typography from "@mui/joy/Typography";
+import Button from "@mui/joy/Button";
+import Stack from "@mui/joy/Stack";
+import type { ConfirmDialogSlotProps } from "../types.js";
+
+/**
+ * Joy UI ConfirmDialog — Modal + ModalDialog based on the example app pattern.
+ */
+export function ConfirmDialog({
+  open,
+  onClose,
+  onConfirm,
+  title,
+  description,
+  confirmLabel = "Confirm",
+  cancelLabel = "Cancel",
+  variant = "default",
+}: ConfirmDialogSlotProps): ReactElement {
+  const dialog = createElement(
+    ModalDialog,
+    { variant: "outlined", role: "alertdialog", sx: { maxWidth: 400 } },
+    createElement(Typography, { level: "h4", children: title }),
+    description
+      ? createElement(Typography, { level: "body-md", sx: { mt: 1 }, children: description })
+      : null,
+    createElement(
+      Stack,
+      { direction: "row", spacing: 1, justifyContent: "flex-end", sx: { mt: 2 } },
+      createElement(Button, { variant: "plain", color: "neutral", onClick: onClose, children: cancelLabel }),
+      createElement(Button, {
+        variant: "solid",
+        color: variant === "danger" ? "danger" : "primary",
+        onClick: onConfirm,
+        children: confirmLabel,
+      }),
+    ),
+  );
+
+  return createElement(Modal, { open, onClose, children: dialog });
+}

--- a/packages/ui/src/joy/form-status.tsx
+++ b/packages/ui/src/joy/form-status.tsx
@@ -1,0 +1,51 @@
+import { createElement, type ReactElement } from "react";
+import Alert from "@mui/joy/Alert";
+import Stack from "@mui/joy/Stack";
+import type { FormStatusProps } from "../types.js";
+
+/**
+ * Joy UI FormStatus — displays action result feedback as Joy Alerts.
+ */
+export function FormStatus({ data }: FormStatusProps): ReactElement | null {
+  if (!data) return null;
+
+  const elements: ReactElement[] = [];
+
+  if (data.success) {
+    elements.push(
+      createElement(Alert, { key: "success", color: "success", variant: "soft", children: data.success }),
+    );
+  }
+
+  if (data.error) {
+    elements.push(
+      createElement(Alert, { key: "error", color: "danger", variant: "soft", children: data.error }),
+    );
+  }
+
+  if (data.fieldErrors) {
+    const errorMessages = Object.entries(data.fieldErrors)
+      .flatMap(([field, errors]) =>
+        errors.map((err) => `${field}: ${err}`),
+      );
+    if (errorMessages.length > 0) {
+      elements.push(
+        createElement(
+          Alert,
+          { key: "field-errors", color: "danger", variant: "soft" },
+          createElement(
+            "ul",
+            { style: { margin: 0, paddingLeft: "16px" } },
+            ...errorMessages.map((msg, i) =>
+              createElement("li", { key: i }, msg),
+            ),
+          ),
+        ),
+      );
+    }
+  }
+
+  if (elements.length === 0) return null;
+
+  return createElement(Stack, { spacing: 1 }, ...elements);
+}

--- a/packages/ui/src/joy/toast-provider.tsx
+++ b/packages/ui/src/joy/toast-provider.tsx
@@ -1,0 +1,35 @@
+import { createElement, useCallback, type ReactElement } from "react";
+import type { ReactNode } from "react";
+import { toast, Toaster } from "sonner";
+import { ToastContext } from "../hooks/use-toast.js";
+import type { ToastOptions } from "../types.js";
+
+/**
+ * Joy UI ToastProvider backed by Sonner.
+ */
+export function ToastProvider({ children }: { children: ReactNode }): ReactElement {
+  const show = useCallback((options: ToastOptions) => {
+    const method = options.type ?? "info";
+    switch (method) {
+      case "success":
+        toast.success(options.message, { description: options.description, duration: options.duration });
+        break;
+      case "error":
+        toast.error(options.message, { description: options.description, duration: options.duration });
+        break;
+      case "warning":
+        toast.warning(options.message, { description: options.description, duration: options.duration });
+        break;
+      default:
+        toast.info(options.message, { description: options.description, duration: options.duration });
+        break;
+    }
+  }, []);
+
+  return createElement(
+    ToastContext.Provider,
+    { value: { show } },
+    children,
+    createElement(Toaster, { richColors: true, position: "bottom-right" }),
+  );
+}


### PR DESCRIPTION
## Summary
- `ConfirmProvider` + `useConfirm()` — imperative `Promise<boolean>` confirmation dialog
- `ToastProvider` + `useToast()` — context-based toast API
- `useActionToast(descriptor, config)` — auto-toast on action results
- `FormStatus` — renders success/error/fieldErrors from action data
- Joy implementations: Modal+ModalDialog confirm, Sonner-backed toasts, Alert form status

## Test plan
- [x] `pnpm test` — 13 new tests pass (35 total)
- [x] `pnpm typecheck` — no errors
- [x] `pnpm build` — clean

> Part 3 of 10. Depends on PR 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)