### PR TITLE
feat(ui): PR 3 — utility components

### DIFF
--- a/packages/ui/src/client.ts
+++ b/packages/ui/src/client.ts
@@ -14,3 +14,6 @@ export { PermissionGate } from "./components/permission-gate.js";
 export { ActionButton } from "./components/action-button.js";
 export { ConfirmProvider } from "./components/confirm-provider.js";
 export { FormStatus } from "./components/form-status.js";
+export { AvatarWithInitials, getInitials } from "./components/avatar-with-initials.js";
+export { RoleBadge } from "./components/role-badge.js";
+export { ImpersonationBanner } from "./components/impersonation-banner.js";

--- a/packages/ui/src/components/avatar-with-initials.test.tsx
+++ b/packages/ui/src/components/avatar-with-initials.test.tsx
@@ -1,0 +1,43 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import { createElement } from "react";
+import { AvatarWithInitials, getInitials } from "./avatar-with-initials.js";
+
+afterEach(cleanup);
+
+describe("getInitials", () => {
+  it("extracts two initials from a full name", () => {
+    expect(getInitials("Daniel Schmidt")).toBe("DS");
+  });
+
+  it("handles single name", () => {
+    expect(getInitials("Daniel")).toBe("D");
+  });
+
+  it("truncates to 2 chars for 3+ word names", () => {
+    expect(getInitials("John Paul Jones")).toBe("JP");
+  });
+});
+
+describe("AvatarWithInitials", () => {
+  it("renders initials when no src provided", () => {
+    render(createElement(AvatarWithInitials, { name: "Daniel Schmidt" }));
+    expect(screen.getByText("DS")).toBeTruthy();
+  });
+
+  it("renders image when src is provided", () => {
+    render(
+      createElement(AvatarWithInitials, {
+        name: "Daniel Schmidt",
+        src: "https://example.com/avatar.jpg",
+      }),
+    );
+    const img = screen.getByAltText("Daniel Schmidt") as HTMLImageElement;
+    expect(img.src).toBe("https://example.com/avatar.jpg");
+  });
+
+  it("renders initials when src is null", () => {
+    render(createElement(AvatarWithInitials, { name: "Test User", src: null }));
+    expect(screen.getByText("TU")).toBeTruthy();
+  });
+});

--- a/packages/ui/src/components/avatar-with-initials.tsx
+++ b/packages/ui/src/components/avatar-with-initials.tsx
@@ -1,0 +1,59 @@
+import { createElement } from "react";
+import type { AvatarWithInitialsProps } from "../types.js";
+
+/**
+ * Extracts up to 2 initials from a name.
+ */
+export function getInitials(name: string): string {
+  return name
+    .split(" ")
+    .map((part) => part[0])
+    .join("")
+    .toUpperCase()
+    .slice(0, 2);
+}
+
+const sizeMap = { sm: 32, md: 40, lg: 56 } as const;
+
+/**
+ * Headless AvatarWithInitials — renders an img or initials span.
+ */
+export function AvatarWithInitials({
+  src,
+  name,
+  size = "md",
+}: AvatarWithInitialsProps) {
+  const px = sizeMap[size];
+
+  if (src) {
+    return createElement("img", {
+      src,
+      alt: name,
+      style: {
+        width: px,
+        height: px,
+        borderRadius: "50%",
+        objectFit: "cover" as const,
+      },
+    });
+  }
+
+  return createElement(
+    "span",
+    {
+      "aria-label": name,
+      style: {
+        display: "inline-flex",
+        alignItems: "center",
+        justifyContent: "center",
+        width: px,
+        height: px,
+        borderRadius: "50%",
+        backgroundColor: "#ddd",
+        fontSize: px * 0.4,
+        fontWeight: "bold",
+      },
+    },
+    getInitials(name),
+  );
+}

--- a/packages/ui/src/components/impersonation-banner.test.tsx
+++ b/packages/ui/src/components/impersonation-banner.test.tsx
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import { createElement } from "react";
+import { ImpersonationBanner } from "./impersonation-banner.js";
+
+afterEach(cleanup);
+
+// Mock @cfast/auth/client
+vi.mock("@cfast/auth/client", () => ({
+  useCurrentUser: vi.fn(),
+}));
+
+import { useCurrentUser } from "@cfast/auth/client";
+const mockUseCurrentUser = vi.mocked(useCurrentUser);
+
+describe("ImpersonationBanner", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders nothing when not impersonating", () => {
+    mockUseCurrentUser.mockReturnValue({
+      id: "1",
+      email: "user@example.com",
+      name: "Test User",
+      avatarUrl: null,
+      roles: ["admin"],
+      isImpersonating: false,
+    });
+
+    const { container } = render(createElement(ImpersonationBanner, {}));
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("renders nothing when user is null", () => {
+    mockUseCurrentUser.mockReturnValue(null);
+
+    const { container } = render(createElement(ImpersonationBanner, {}));
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("renders banner when impersonating", () => {
+    mockUseCurrentUser.mockReturnValue({
+      id: "2",
+      email: "impersonated@example.com",
+      name: "Impersonated User",
+      avatarUrl: null,
+      roles: ["reader"],
+      isImpersonating: true,
+      realUser: { id: "1", name: "Admin" },
+    });
+
+    render(createElement(ImpersonationBanner, {}));
+    expect(screen.getByText("Viewing as Impersonated User (impersonated@example.com)")).toBeTruthy();
+    expect(screen.getByText("Stop Impersonating")).toBeTruthy();
+  });
+
+  it("uses custom stop action URL", () => {
+    mockUseCurrentUser.mockReturnValue({
+      id: "2",
+      email: "user@example.com",
+      name: "User",
+      avatarUrl: null,
+      roles: [],
+      isImpersonating: true,
+    });
+
+    render(createElement(ImpersonationBanner, { stopAction: "/custom/stop" }));
+    const form = screen.getByText("Stop Impersonating").closest("form") as HTMLFormElement;
+    expect(form.getAttribute("action")).toBe("/custom/stop");
+  });
+});

--- a/packages/ui/src/components/impersonation-banner.tsx
+++ b/packages/ui/src/components/impersonation-banner.tsx
@@ -1,0 +1,53 @@
+import { createElement } from "react";
+import { useCurrentUser } from "@cfast/auth/client";
+import { useComponent } from "../plugin.js";
+import type { ImpersonationBannerProps } from "../types.js";
+
+/**
+ * Persistent banner shown when an admin is impersonating another user.
+ * Hidden when not impersonating.
+ */
+export function ImpersonationBanner({
+  stopAction = "/admin/stop-impersonation",
+}: ImpersonationBannerProps) {
+  const user = useCurrentUser();
+  const Alert = useComponent("alert");
+  const Button = useComponent("button");
+
+  if (!user?.isImpersonating) {
+    return null;
+  }
+
+  return createElement(
+    Alert,
+    {
+      color: "warning",
+      children: createElement(
+        "div",
+        {
+          style: {
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            gap: "12px",
+          },
+        },
+        createElement(
+          "strong",
+          null,
+          `Viewing as ${user.name} (${user.email})`,
+        ),
+        createElement(
+          "form",
+          { method: "post", action: stopAction },
+          createElement(Button, {
+            type: "submit",
+            variant: "outlined",
+            size: "sm",
+            children: "Stop Impersonating",
+          }),
+        ),
+      ),
+    },
+  );
+}

--- a/packages/ui/src/components/role-badge.test.tsx
+++ b/packages/ui/src/components/role-badge.test.tsx
@@ -1,0 +1,28 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import { createElement } from "react";
+import { RoleBadge } from "./role-badge.js";
+
+afterEach(cleanup);
+
+describe("RoleBadge", () => {
+  it("renders the role text", () => {
+    render(createElement(RoleBadge, { role: "admin" }));
+    expect(screen.getByText("admin")).toBeTruthy();
+  });
+
+  it("renders with custom colors without error", () => {
+    render(
+      createElement(RoleBadge, {
+        role: "moderator",
+        colors: { moderator: "warning" },
+      }),
+    );
+    expect(screen.getByText("moderator")).toBeTruthy();
+  });
+
+  it("falls back to neutral for unknown roles", () => {
+    render(createElement(RoleBadge, { role: "unknown" }));
+    expect(screen.getByText("unknown")).toBeTruthy();
+  });
+});

--- a/packages/ui/src/components/role-badge.tsx
+++ b/packages/ui/src/components/role-badge.tsx
@@ -1,0 +1,31 @@
+import { createElement } from "react";
+import { useComponent } from "../plugin.js";
+import type { RoleBadgeProps, ChipSlotProps } from "../types.js";
+
+const defaultColors: Record<string, ChipSlotProps["color"]> = {
+  admin: "danger",
+  editor: "primary",
+  author: "success",
+  reader: "neutral",
+};
+
+/**
+ * Colored badge displaying a user's role.
+ * Uses the plugin's `chip` slot for rendering.
+ */
+export function RoleBadge({ role, colors }: RoleBadgeProps) {
+  const Chip = useComponent("chip");
+  const colorMap = colors
+    ? { ...defaultColors, ...Object.fromEntries(
+        Object.entries(colors).map(([k, v]) => [k, v as ChipSlotProps["color"]]),
+      )}
+    : defaultColors;
+  const chipColor = colorMap[role] ?? "neutral";
+
+  return createElement(Chip, {
+    children: role,
+    color: chipColor,
+    variant: "soft",
+    size: "sm",
+  });
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -12,6 +12,9 @@ export { PermissionGate } from "./components/permission-gate.js";
 export { ActionButton } from "./components/action-button.js";
 export { ConfirmProvider } from "./components/confirm-provider.js";
 export { FormStatus } from "./components/form-status.js";
+export { AvatarWithInitials, getInitials } from "./components/avatar-with-initials.js";
+export { RoleBadge } from "./components/role-badge.js";
+export { ImpersonationBanner } from "./components/impersonation-banner.js";
 
 // Types
 export type {

--- a/packages/ui/src/joy.ts
+++ b/packages/ui/src/joy.ts
@@ -5,3 +5,8 @@ export { ActionButton } from "./joy/action-button.js";
 export { ConfirmDialog } from "./joy/confirm-dialog.js";
 export { ToastProvider } from "./joy/toast-provider.js";
 export { FormStatus } from "./joy/form-status.js";
+
+// Utilities
+export { AvatarWithInitials } from "./joy/avatar-with-initials.js";
+export { RoleBadge } from "./joy/role-badge.js";
+export { ImpersonationBanner } from "./joy/impersonation-banner.js";

--- a/packages/ui/src/joy/avatar-with-initials.tsx
+++ b/packages/ui/src/joy/avatar-with-initials.tsx
@@ -1,0 +1,20 @@
+import { createElement, type ReactElement } from "react";
+import Avatar from "@mui/joy/Avatar";
+import type { AvatarWithInitialsProps } from "../types.js";
+import { getInitials } from "../components/avatar-with-initials.js";
+
+/**
+ * Joy UI AvatarWithInitials — MUI Joy Avatar with initials fallback.
+ */
+export function AvatarWithInitials({
+  src,
+  name,
+  size = "md",
+}: AvatarWithInitialsProps): ReactElement {
+  return createElement(Avatar, {
+    src: src ?? undefined,
+    alt: name,
+    size,
+    children: getInitials(name),
+  });
+}

--- a/packages/ui/src/joy/impersonation-banner.tsx
+++ b/packages/ui/src/joy/impersonation-banner.tsx
@@ -1,0 +1,55 @@
+import { createElement, type ReactElement } from "react";
+import Sheet from "@mui/joy/Sheet";
+import Typography from "@mui/joy/Typography";
+import Button from "@mui/joy/Button";
+import Stack from "@mui/joy/Stack";
+import { useCurrentUser } from "@cfast/auth/client";
+import type { ImpersonationBannerProps } from "../types.js";
+
+/**
+ * Joy UI ImpersonationBanner — sticky warning sheet when impersonating.
+ */
+export function ImpersonationBanner({
+  stopAction = "/admin/stop-impersonation",
+}: ImpersonationBannerProps): ReactElement | null {
+  const user = useCurrentUser();
+
+  if (!user?.isImpersonating) {
+    return null;
+  }
+
+  return createElement(
+    Sheet,
+    {
+      color: "warning",
+      variant: "solid",
+      sx: {
+        position: "sticky",
+        top: 0,
+        zIndex: 1100,
+        py: 1,
+        px: 3,
+      },
+    },
+    createElement(
+      Stack,
+      { direction: "row", spacing: 2, alignItems: "center", justifyContent: "center" },
+      createElement(Typography, {
+        level: "body-sm",
+        sx: { fontWeight: "bold" },
+        children: `Viewing as ${user.name} (${user.email})`,
+      }),
+      createElement(
+        "form",
+        { method: "post", action: stopAction },
+        createElement(Button, {
+          size: "sm",
+          variant: "outlined",
+          color: "warning",
+          type: "submit",
+          children: "Stop Impersonating",
+        }),
+      ),
+    ),
+  );
+}

--- a/packages/ui/src/joy/role-badge.tsx
+++ b/packages/ui/src/joy/role-badge.tsx
@@ -1,0 +1,30 @@
+import { createElement, type ReactElement } from "react";
+import Chip from "@mui/joy/Chip";
+import type { ColorPaletteProp } from "@mui/joy/styles";
+import type { RoleBadgeProps } from "../types.js";
+
+const defaultColors: Record<string, ColorPaletteProp> = {
+  admin: "danger",
+  editor: "primary",
+  author: "success",
+  reader: "neutral",
+};
+
+/**
+ * Joy UI RoleBadge — MUI Joy Chip with configurable color per role.
+ */
+export function RoleBadge({ role, colors }: RoleBadgeProps): ReactElement {
+  const colorMap = colors
+    ? { ...defaultColors, ...Object.fromEntries(
+        Object.entries(colors).map(([k, v]) => [k, v as ColorPaletteProp]),
+      )}
+    : defaultColors;
+  const chipColor = colorMap[role] ?? ("neutral" satisfies ColorPaletteProp);
+
+  return createElement(Chip, {
+    size: "sm",
+    variant: "soft",
+    color: chipColor,
+    children: role,
+  });
+}


### PR DESCRIPTION
## Summary
- `AvatarWithInitials` — extracts initials from name, renders avatar with fallback
- `RoleBadge` — colored badge via plugin chip slot, configurable color map
- `ImpersonationBanner` — uses `useCurrentUser()`, shows warning when impersonating
- Joy implementations: MUI Avatar, Chip, Sheet respectively

## Test plan
- [x] `pnpm test` — 13 new tests pass (48 total)
- [x] `pnpm typecheck` — no errors
- [x] `pnpm build` — clean

> Part 4 of 10. Depends on PR 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)