### PR TITLE
feat(ui): PR 5 — EmptyState + NavigationProgress

### DIFF
--- a/packages/ui/src/components/empty-state.test.tsx
+++ b/packages/ui/src/components/empty-state.test.tsx
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, cleanup, fireEvent } from "@testing-library/react";
+import { createElement } from "react";
+import { EmptyState } from "./empty-state.js";
+import { createMockDescriptor } from "../__tests__/helpers.js";
+
+afterEach(cleanup);
+
+// Mock useActionStatus
+vi.mock("../hooks/use-action-status.js", () => ({
+  useActionStatus: vi.fn(),
+}));
+
+import { useActionStatus } from "../hooks/use-action-status.js";
+const mockUseActionStatus = vi.mocked(useActionStatus);
+
+describe("EmptyState", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders title and description without createAction", () => {
+    render(
+      createElement(EmptyState, {
+        title: "No posts yet",
+        description: "Create your first post.",
+      }),
+    );
+    expect(screen.getByText("No posts yet")).toBeTruthy();
+    expect(screen.getByText("Create your first post.")).toBeTruthy();
+  });
+
+  it("shows CTA when createAction is permitted", () => {
+    const submitFn = vi.fn();
+    mockUseActionStatus.mockReturnValue({
+      permitted: true,
+      invisible: false,
+      reason: null,
+      submit: submitFn,
+      pending: false,
+      data: undefined,
+      error: undefined,
+    });
+
+    const descriptor = createMockDescriptor(["createPost"]);
+    render(
+      createElement(EmptyState, {
+        title: "No posts",
+        createAction: descriptor,
+        createLabel: "New Post",
+      }),
+    );
+
+    const button = screen.getByText("New Post");
+    expect(button).toBeTruthy();
+    fireEvent.click(button);
+    expect(submitFn).toHaveBeenCalled();
+  });
+
+  it("hides CTA when not permitted", () => {
+    mockUseActionStatus.mockReturnValue({
+      permitted: false,
+      invisible: false,
+      reason: "No permission",
+      submit: vi.fn(),
+      pending: false,
+      data: undefined,
+      error: undefined,
+    });
+
+    const descriptor = createMockDescriptor(["createPost"]);
+    render(
+      createElement(EmptyState, {
+        title: "No posts",
+        description: "Talk to an admin.",
+        createAction: descriptor,
+        createLabel: "New Post",
+      }),
+    );
+
+    expect(screen.getByText("No posts")).toBeTruthy();
+    expect(screen.getByText("Talk to an admin.")).toBeTruthy();
+    expect(screen.queryByText("New Post")).toBeNull();
+  });
+
+  it("shows generic message when invisible", () => {
+    mockUseActionStatus.mockReturnValue({
+      permitted: false,
+      invisible: true,
+      reason: null,
+      submit: vi.fn(),
+      pending: false,
+      data: undefined,
+      error: undefined,
+    });
+
+    const descriptor = createMockDescriptor(["createPost"]);
+    render(
+      createElement(EmptyState, {
+        title: "No posts",
+        createAction: descriptor,
+      }),
+    );
+
+    expect(screen.getByText("Nothing here yet")).toBeTruthy();
+  });
+});

--- a/packages/ui/src/components/empty-state.tsx
+++ b/packages/ui/src/components/empty-state.tsx
@@ -1,0 +1,81 @@
+import { createElement } from "react";
+import { useActionStatus } from "../hooks/use-action-status.js";
+import { useComponent } from "../plugin.js";
+import type { EmptyStateProps } from "../types.js";
+
+/**
+ * Permission-aware empty state.
+ *
+ * - If createAction is permitted: shows title + description + CTA button
+ * - If createAction is forbidden: shows title + description only
+ * - If createAction is invisible: shows generic message
+ * - If no createAction: shows title + description
+ */
+export function EmptyState({
+  title,
+  description,
+  createAction,
+  createLabel = "Create",
+  icon: Icon,
+}: EmptyStateProps) {
+  const Button = useComponent("button");
+
+  // If no create action, just show the message
+  if (!createAction) {
+    return createElement(
+      "div",
+      { style: { textAlign: "center" as const, padding: "48px 16px" } },
+      Icon ? createElement(Icon, { className: "empty-state-icon" }) : null,
+      createElement("h3", { style: { margin: "16px 0 8px" } }, title),
+      description ? createElement("p", { style: { color: "#666" } }, description) : null,
+    );
+  }
+
+  return createElement(EmptyStateWithAction, {
+    title,
+    description,
+    createAction,
+    createLabel,
+    icon: Icon,
+    Button,
+  });
+}
+
+function EmptyStateWithAction({
+  title,
+  description,
+  createAction,
+  createLabel,
+  icon: Icon,
+  Button,
+}: EmptyStateProps & { Button: ReturnType<typeof useComponent<"button">> }) {
+  const status = useActionStatus(createAction!);
+
+  // If invisible, show generic message
+  if (status.invisible) {
+    return createElement(
+      "div",
+      { style: { textAlign: "center" as const, padding: "48px 16px" } },
+      createElement("h3", { style: { margin: "16px 0 8px" } }, "Nothing here yet"),
+    );
+  }
+
+  return createElement(
+    "div",
+    { style: { textAlign: "center" as const, padding: "48px 16px" } },
+    Icon ? createElement(Icon, { className: "empty-state-icon" }) : null,
+    createElement("h3", { style: { margin: "16px 0 8px" } }, title),
+    description ? createElement("p", { style: { color: "#666" } }, description) : null,
+    status.permitted
+      ? createElement(
+          "div",
+          { style: { marginTop: "16px" } },
+          createElement(Button, {
+            children: createLabel,
+            onClick: () => status.submit(),
+            loading: status.pending,
+          }),
+        )
+      : null,
+  );
+}

--- a/packages/ui/src/components/navigation-progress.test.tsx
+++ b/packages/ui/src/components/navigation-progress.test.tsx
@@ -1,0 +1,38 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import { createElement } from "react";
+import { NavigationProgress } from "./navigation-progress.js";
+
+afterEach(cleanup);
+
+// Mock react-router
+vi.mock("react-router", () => ({
+  useNavigation: vi.fn(),
+}));
+
+import { useNavigation } from "react-router";
+const mockUseNavigation = vi.mocked(useNavigation);
+
+describe("NavigationProgress", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders nothing when idle", () => {
+    mockUseNavigation.mockReturnValue({
+      state: "idle",
+    } as ReturnType<typeof useNavigation>);
+
+    const { container } = render(createElement(NavigationProgress, {}));
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("renders progress bar when loading", () => {
+    mockUseNavigation.mockReturnValue({
+      state: "loading",
+    } as ReturnType<typeof useNavigation>);
+
+    render(createElement(NavigationProgress, {}));
+    expect(screen.getByRole("progressbar")).toBeTruthy();
+  });
+});

--- a/packages/ui/src/components/navigation-progress.tsx
+++ b/packages/ui/src/components/navigation-progress.tsx
@@ -1,0 +1,33 @@
+import { createElement } from "react";
+import { useNavigation } from "react-router";
+import type { NavigationProgressProps } from "../types.js";
+
+/**
+ * Thin progress bar at the top of the page during React Router navigation.
+ * Shows when navigation state is "loading", hides when "idle".
+ */
+export function NavigationProgress({
+  color = "#1976d2",
+}: NavigationProgressProps) {
+  const navigation = useNavigation();
+  const isNavigating = navigation.state === "loading";
+
+  if (!isNavigating) {
+    return null;
+  }
+
+  return createElement("div", {
+    role: "progressbar",
+    "aria-label": "Loading",
+    style: {
+      position: "fixed" as const,
+      top: 0,
+      left: 0,
+      right: 0,
+      height: "3px",
+      backgroundColor: color,
+      zIndex: 9999,
+      animation: "nav-progress 2s ease-in-out infinite",
+    },
+  });
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -22,6 +22,8 @@ export {
 } from "./fields/index.js";
 export { RoleBadge } from "./components/role-badge.js";
 export { ImpersonationBanner } from "./components/impersonation-banner.js";
+export { EmptyState } from "./components/empty-state.js";
+export { NavigationProgress } from "./components/navigation-progress.js";
 
 // Types
 export type {

--- a/packages/ui/src/joy.ts
+++ b/packages/ui/src/joy.ts
@@ -6,6 +6,10 @@ export { ConfirmDialog } from "./joy/confirm-dialog.js";
 export { ToastProvider } from "./joy/toast-provider.js";
 export { FormStatus } from "./joy/form-status.js";
 
+// Empty state & navigation
+export { EmptyState } from "./joy/empty-state.js";
+export { NavigationProgress } from "./joy/navigation-progress.js";
+
 // Utilities
 export { AvatarWithInitials } from "./joy/avatar-with-initials.js";
 export { RoleBadge } from "./joy/role-badge.js";

--- a/packages/ui/src/joy/empty-state.tsx
+++ b/packages/ui/src/joy/empty-state.tsx
@@ -1,0 +1,68 @@
+import { createElement, type ReactElement } from "react";
+import Typography from "@mui/joy/Typography";
+import Button from "@mui/joy/Button";
+import Stack from "@mui/joy/Stack";
+import { useActionStatus } from "../hooks/use-action-status.js";
+import type { EmptyStateProps } from "../types.js";
+
+/**
+ * Joy UI EmptyState — centered layout with optional CTA.
+ */
+export function EmptyState({
+  title,
+  description,
+  createAction,
+  createLabel = "Create",
+  icon: Icon,
+}: EmptyStateProps): ReactElement {
+  if (!createAction) {
+    return createElement(
+      Stack,
+      { alignItems: "center", spacing: 2, sx: { py: 6, px: 2 } },
+      Icon ? createElement(Icon, { className: "empty-state-icon" }) : null,
+      createElement(Typography, { level: "h3", children: title }),
+      description ? createElement(Typography, { level: "body-md", color: "neutral", children: description }) : null,
+    );
+  }
+
+  return createElement(EmptyStateWithAction, {
+    title,
+    description,
+    createAction,
+    createLabel,
+    icon: Icon,
+  });
+}
+
+function EmptyStateWithAction({
+  title,
+  description,
+  createAction,
+  createLabel,
+  icon: Icon,
+}: EmptyStateProps): ReactElement {
+  const status = useActionStatus(createAction!);
+
+  if (status.invisible) {
+    return createElement(
+      Stack,
+      { alignItems: "center", spacing: 2, sx: { py: 6, px: 2 } },
+      createElement(Typography, { level: "h3", children: "Nothing here yet" }),
+    );
+  }
+
+  return createElement(
+    Stack,
+    { alignItems: "center", spacing: 2, sx: { py: 6, px: 2 } },
+    Icon ? createElement(Icon, { className: "empty-state-icon" }) : null,
+    createElement(Typography, { level: "h3", children: title }),
+    description ? createElement(Typography, { level: "body-md", color: "neutral", children: description }) : null,
+    status.permitted
+      ? createElement(Button, {
+          onClick: () => status.submit(),
+          loading: status.pending,
+          children: createLabel,
+        })
+      : null,
+  );
+}

--- a/packages/ui/src/joy/navigation-progress.tsx
+++ b/packages/ui/src/joy/navigation-progress.tsx
@@ -1,0 +1,27 @@
+import { createElement, type ReactElement } from "react";
+import LinearProgress from "@mui/joy/LinearProgress";
+import { useNavigation } from "react-router";
+
+/**
+ * Joy UI NavigationProgress — LinearProgress with absolute positioning.
+ */
+export function NavigationProgress(): ReactElement | null {
+  const navigation = useNavigation();
+  const isNavigating = navigation.state === "loading";
+
+  if (!isNavigating) {
+    return null;
+  }
+
+  return createElement(LinearProgress, {
+    sx: {
+      position: "fixed",
+      top: 0,
+      left: 0,
+      right: 0,
+      zIndex: 9999,
+      "--LinearProgress-radius": "0px",
+      "--LinearProgress-thickness": "3px",
+    },
+  });
+}


### PR DESCRIPTION
## Summary
- `EmptyState` — permission-aware empty state with optional create CTA
- `NavigationProgress` — route transition progress bar via `useNavigation()`
- Joy implementations: Stack-based EmptyState, LinearProgress bar

## Test plan
- [x] `pnpm test` — 6 new tests pass (78 total)
- [x] `pnpm typecheck` — no errors
- [x] `pnpm build` — clean

> Part 6 of 10. Depends on PR 4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)