### PR TITLE
feat(ui): PR 8 — file components (DropZone, ImagePreview, FileList)

### DIFF
--- a/packages/ui/src/client.ts
+++ b/packages/ui/src/client.ts
@@ -21,3 +21,6 @@ export { DataTable } from "./components/data-table.js";
 export { FilterBar } from "./components/filter-bar.js";
 export { BulkActionBar } from "./components/bulk-action-bar.js";
 export { useColumnInference } from "./hooks/use-column-inference.js";
+export { DropZone } from "./components/drop-zone.js";
+export { ImagePreview } from "./components/image-preview.js";
+export { FileList } from "./components/file-list.js";

--- a/packages/ui/src/components/drop-zone.test.tsx
+++ b/packages/ui/src/components/drop-zone.test.tsx
@@ -1,0 +1,98 @@
+// @vitest-environment jsdom
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { render, screen, cleanup, fireEvent } from "@testing-library/react";
+import { createElement } from "react";
+import { DropZone } from "./drop-zone.js";
+
+vi.mock("../plugin.js", () => ({
+  useComponent: () =>
+    ({
+      children,
+      onClick,
+      isDragOver,
+    }: {
+      children: unknown;
+      onClick: () => void;
+      isDragOver: boolean;
+    }) =>
+      createElement(
+        "div",
+        {
+          "data-testid": "dropzone",
+          "data-drag-over": isDragOver,
+          onClick,
+        },
+        children as string,
+      ),
+}));
+
+afterEach(cleanup);
+
+function makeMockUpload(overrides?: Record<string, unknown>) {
+  return {
+    accept: "image/*",
+    start: vi.fn(),
+    progress: 0,
+    isUploading: false,
+    result: null,
+    error: null,
+    validationError: null,
+    reset: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe("DropZone", () => {
+  it("renders default content", () => {
+    render(createElement(DropZone, { upload: makeMockUpload() }));
+    expect(screen.getByText("Drop files here or click to browse")).toBeTruthy();
+  });
+
+  it("shows upload progress", () => {
+    render(
+      createElement(DropZone, {
+        upload: makeMockUpload({ isUploading: true, progress: 42 }),
+      }),
+    );
+    expect(screen.getByText("Uploading... 42%")).toBeTruthy();
+  });
+
+  it("shows error message", () => {
+    render(
+      createElement(DropZone, {
+        upload: makeMockUpload({ error: "Upload failed" }),
+      }),
+    );
+    expect(screen.getByText("Upload failed")).toBeTruthy();
+  });
+
+  it("shows validation error", () => {
+    render(
+      createElement(DropZone, {
+        upload: makeMockUpload({ validationError: "File too large" }),
+      }),
+    );
+    expect(screen.getByText("File too large")).toBeTruthy();
+  });
+
+  it("renders custom children", () => {
+    render(
+      createElement(DropZone, {
+        upload: makeMockUpload(),
+        children: createElement("span", null, "Custom content"),
+      }),
+    );
+    expect(screen.getByText("Custom content")).toBeTruthy();
+  });
+
+  it("triggers file input on click", () => {
+    render(createElement(DropZone, { upload: makeMockUpload() }));
+    const dropzone = screen.getByTestId("dropzone");
+    // Click should propagate to the hidden input
+    fireEvent.click(dropzone);
+    // The hidden input exists
+    const input = document.querySelector("input[type='file']");
+    expect(input).toBeTruthy();
+    expect(input?.getAttribute("accept")).toBe("image/*");
+  });
+});

--- a/packages/ui/src/components/drop-zone.tsx
+++ b/packages/ui/src/components/drop-zone.tsx
@@ -1,0 +1,78 @@
+import { createElement, useState, useCallback, useRef } from "react";
+import { useComponent } from "../plugin.js";
+import type { DropZoneProps } from "../types.js";
+
+/**
+ * Headless DropZone — drag-and-drop file upload area.
+ * Integrates with `useUpload()` from `@cfast/storage/client`.
+ */
+export function DropZone({
+  upload,
+  multiple = false,
+  children,
+}: DropZoneProps) {
+  const DropZoneSlot = useComponent("dropZone");
+  const [isDragOver, setIsDragOver] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const handleFiles = useCallback(
+    (files: FileList | null) => {
+      if (!files || files.length === 0) return;
+      if (multiple) {
+        for (let i = 0; i < files.length; i++) {
+          upload.start(files[i]);
+        }
+      } else {
+        upload.start(files[0]);
+      }
+    },
+    [upload, multiple],
+  );
+
+  const handleDrop = useCallback(
+    (files: FileList) => {
+      setIsDragOver(false);
+      handleFiles(files);
+    },
+    [handleFiles],
+  );
+
+  const handleClick = useCallback(() => {
+    inputRef.current?.click();
+  }, []);
+
+  const handleDragOver = useCallback((_e: unknown) => {
+    setIsDragOver(true);
+  }, []);
+
+  const handleDragLeave = useCallback(() => {
+    setIsDragOver(false);
+  }, []);
+
+  const defaultContent = upload.isUploading
+    ? `Uploading... ${upload.progress}%`
+    : upload.error ?? upload.validationError ?? "Drop files here or click to browse";
+
+  return createElement(
+    "div",
+    null,
+    createElement(DropZoneSlot, {
+      isDragOver,
+      isInvalid: !!(upload.error || upload.validationError),
+      onClick: handleClick,
+      onDrop: handleDrop,
+      onDragOver: handleDragOver,
+      onDragLeave: handleDragLeave,
+      accept: upload.accept,
+      children: children ?? defaultContent,
+    }),
+    createElement("input", {
+      ref: inputRef,
+      type: "file",
+      accept: upload.accept,
+      multiple,
+      style: { display: "none" },
+      onChange: (e: React.ChangeEvent<HTMLInputElement>) => handleFiles(e.target.files),
+    }),
+  );
+}

--- a/packages/ui/src/components/file-list.test.tsx
+++ b/packages/ui/src/components/file-list.test.tsx
@@ -1,0 +1,52 @@
+// @vitest-environment jsdom
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { render, screen, cleanup, fireEvent } from "@testing-library/react";
+import { createElement } from "react";
+import { FileList } from "./file-list.js";
+
+afterEach(cleanup);
+
+const sampleFiles = [
+  { key: "f1", name: "report.pdf", size: 1024 * 512, url: "/files/f1" },
+  { key: "f2", name: "photo.jpg", size: 2048 * 1024, url: "/files/f2" },
+];
+
+describe("FileList", () => {
+  it("renders file names", () => {
+    render(createElement(FileList, { files: sampleFiles }));
+    expect(screen.getByText("report.pdf")).toBeTruthy();
+    expect(screen.getByText("photo.jpg")).toBeTruthy();
+  });
+
+  it("formats file sizes", () => {
+    render(createElement(FileList, { files: sampleFiles }));
+    expect(screen.getByText("512.0 KB")).toBeTruthy();
+    expect(screen.getByText("2.0 MB")).toBeTruthy();
+  });
+
+  it("renders download links when files have urls", () => {
+    render(createElement(FileList, { files: sampleFiles }));
+    const links = screen.getAllByText("Download");
+    expect(links.length).toBe(2);
+    expect(links[0].getAttribute("href")).toBe("/files/f1");
+  });
+
+  it("renders 'No files' for empty list", () => {
+    render(createElement(FileList, { files: [] }));
+    expect(screen.getByText("No files")).toBeTruthy();
+  });
+
+  it("calls onDownload when button clicked", () => {
+    const onDownload = vi.fn();
+    render(
+      createElement(FileList, {
+        files: sampleFiles,
+        onDownload,
+      }),
+    );
+
+    const buttons = screen.getAllByText("Download");
+    fireEvent.click(buttons[0]);
+    expect(onDownload).toHaveBeenCalledWith(sampleFiles[0]);
+  });
+});

--- a/packages/ui/src/components/file-list.tsx
+++ b/packages/ui/src/components/file-list.tsx
@@ -1,0 +1,86 @@
+import { createElement } from "react";
+import type { FileListProps, FileListFile } from "../types.js";
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+/**
+ * Headless FileList — displays a list of files with download links.
+ */
+export function FileList({
+  files,
+  onDownload,
+}: FileListProps) {
+  if (files.length === 0) {
+    return createElement("div", { style: { color: "#999" } }, "No files");
+  }
+
+  return createElement(
+    "ul",
+    {
+      style: { listStyle: "none", padding: 0, margin: 0 },
+      "data-testid": "file-list",
+    },
+    ...files.map((file) =>
+      createElement(FileListItem, {
+        key: file.key,
+        file,
+        onDownload,
+      }),
+    ),
+  );
+}
+
+function FileListItem({
+  file,
+  onDownload,
+}: {
+  file: FileListFile;
+  onDownload?: (file: FileListFile) => void;
+}) {
+  return createElement(
+    "li",
+    {
+      style: {
+        display: "flex",
+        alignItems: "center",
+        gap: "8px",
+        padding: "8px 0",
+        borderBottom: "1px solid #eee",
+      },
+    },
+    createElement("span", { style: { flex: 1 } }, file.name),
+    file.size != null
+      ? createElement("span", { style: { color: "#666", fontSize: "0.85em" } }, formatBytes(file.size))
+      : null,
+    onDownload
+      ? createElement(
+          "button",
+          {
+            onClick: () => onDownload(file),
+            style: {
+              background: "none",
+              border: "none",
+              cursor: "pointer",
+              color: "#1976d2",
+              textDecoration: "underline",
+            },
+          },
+          "Download",
+        )
+      : file.url
+        ? createElement(
+            "a",
+            {
+              href: file.url,
+              download: file.name,
+              style: { color: "#1976d2", textDecoration: "underline" },
+            },
+            "Download",
+          )
+        : null,
+  );
+}

--- a/packages/ui/src/components/image-preview.test.tsx
+++ b/packages/ui/src/components/image-preview.test.tsx
@@ -1,0 +1,65 @@
+// @vitest-environment jsdom
+import { describe, it, expect, afterEach } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import { createElement } from "react";
+import { ImagePreview } from "./image-preview.js";
+
+afterEach(cleanup);
+
+describe("ImagePreview", () => {
+  it("renders image from direct src", () => {
+    render(createElement(ImagePreview, { src: "https://example.com/img.png" }));
+    const img = screen.getByRole("img");
+    expect(img.getAttribute("src")).toBe("https://example.com/img.png");
+  });
+
+  it("resolves src from fileKey + getUrl", () => {
+    render(
+      createElement(ImagePreview, {
+        fileKey: "abc123",
+        getUrl: (key: string) => `/files/${key}`,
+      }),
+    );
+    const img = screen.getByRole("img");
+    expect(img.getAttribute("src")).toBe("/files/abc123");
+  });
+
+  it("prefers direct src over fileKey", () => {
+    render(
+      createElement(ImagePreview, {
+        src: "https://example.com/direct.png",
+        fileKey: "abc123",
+        getUrl: (key: string) => `/files/${key}`,
+      }),
+    );
+    const img = screen.getByRole("img");
+    expect(img.getAttribute("src")).toBe("https://example.com/direct.png");
+  });
+
+  it("renders fallback when no image", () => {
+    render(
+      createElement(ImagePreview, {
+        fallback: createElement("span", null, "No photo"),
+      }),
+    );
+    expect(screen.getByText("No photo")).toBeTruthy();
+  });
+
+  it("renders 'No image' text when no src and no fallback", () => {
+    render(createElement(ImagePreview, {}));
+    expect(screen.getByText("No image")).toBeTruthy();
+  });
+
+  it("applies width and height", () => {
+    render(
+      createElement(ImagePreview, {
+        src: "https://example.com/img.png",
+        width: 300,
+        height: 150,
+      }),
+    );
+    const img = screen.getByRole("img");
+    expect(img.style.width).toBe("300px");
+    expect(img.style.height).toBe("150px");
+  });
+});

--- a/packages/ui/src/components/image-preview.tsx
+++ b/packages/ui/src/components/image-preview.tsx
@@ -1,0 +1,49 @@
+import { createElement } from "react";
+import type { ImagePreviewProps } from "../types.js";
+
+/**
+ * Headless ImagePreview — displays an image from storage or direct src.
+ */
+export function ImagePreview({
+  fileKey,
+  src,
+  getUrl,
+  width = 200,
+  height = 200,
+  fallback,
+  alt = "Image preview",
+}: ImagePreviewProps) {
+  const resolvedSrc = src ?? (fileKey && getUrl ? getUrl(fileKey) : null);
+
+  if (!resolvedSrc) {
+    return fallback
+      ? createElement("div", null, fallback)
+      : createElement(
+          "div",
+          {
+            style: {
+              width,
+              height,
+              backgroundColor: "#f5f5f5",
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              borderRadius: "4px",
+              color: "#999",
+            },
+          },
+          "No image",
+        );
+  }
+
+  return createElement("img", {
+    src: resolvedSrc,
+    alt,
+    style: {
+      width,
+      height,
+      objectFit: "cover" as const,
+      borderRadius: "4px",
+    },
+  });
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -31,6 +31,11 @@ export { DataTable } from "./components/data-table.js";
 export { FilterBar } from "./components/filter-bar.js";
 export { BulkActionBar } from "./components/bulk-action-bar.js";
 
+// File components
+export { DropZone } from "./components/drop-zone.js";
+export { ImagePreview } from "./components/image-preview.js";
+export { FileList } from "./components/file-list.js";
+
 // Hooks — data
 export { useColumnInference } from "./hooks/use-column-inference.js";
 

--- a/packages/ui/src/joy.ts
+++ b/packages/ui/src/joy.ts
@@ -20,6 +20,11 @@ export { DataTable } from "./joy/data-table.js";
 export { FilterBar } from "./joy/filter-bar.js";
 export { BulkActionBar } from "./joy/bulk-action-bar.js";
 
+// File components
+export { DropZone } from "./joy/drop-zone.js";
+export { ImagePreview } from "./joy/image-preview.js";
+export { FileList } from "./joy/file-list.js";
+
 // Utilities
 export { AvatarWithInitials } from "./joy/avatar-with-initials.js";
 export { RoleBadge } from "./joy/role-badge.js";

--- a/packages/ui/src/joy/drop-zone.tsx
+++ b/packages/ui/src/joy/drop-zone.tsx
@@ -1,0 +1,120 @@
+import { createElement, useState, useCallback, useRef, type ReactElement } from "react";
+import JoySheet from "@mui/joy/Sheet";
+import JoyTypography from "@mui/joy/Typography";
+import JoyLinearProgress from "@mui/joy/LinearProgress";
+import type { DropZoneProps } from "../types.js";
+
+/**
+ * Joy UI styled DropZone — drag-and-drop file upload area.
+ */
+export function DropZone({
+  upload,
+  multiple = false,
+  children,
+}: DropZoneProps): ReactElement {
+  const [isDragOver, setIsDragOver] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const handleFiles = useCallback(
+    (files: FileList | null) => {
+      if (!files || files.length === 0) return;
+      if (multiple) {
+        for (let i = 0; i < files.length; i++) {
+          upload.start(files[i]);
+        }
+      } else {
+        upload.start(files[0]);
+      }
+    },
+    [upload, multiple],
+  );
+
+  const handleDrop = useCallback(
+    (e: React.DragEvent) => {
+      e.preventDefault();
+      setIsDragOver(false);
+      handleFiles(e.dataTransfer.files);
+    },
+    [handleFiles],
+  );
+
+  const handleDragOver = useCallback((e: React.DragEvent) => {
+    e.preventDefault();
+    setIsDragOver(true);
+  }, []);
+
+  const handleDragLeave = useCallback(() => {
+    setIsDragOver(false);
+  }, []);
+
+  const handleClick = useCallback(() => {
+    inputRef.current?.click();
+  }, []);
+
+  const hasError = !!(upload.error || upload.validationError);
+
+  return createElement(
+    "div",
+    null,
+    createElement(
+      JoySheet,
+      {
+        variant: "outlined" as const,
+        sx: {
+          borderStyle: "dashed",
+          borderWidth: 2,
+          borderColor: hasError
+            ? "danger.400"
+            : isDragOver
+              ? "primary.400"
+              : "neutral.outlinedBorder",
+          borderRadius: "md",
+          p: 4,
+          textAlign: "center",
+          cursor: "pointer",
+          transition: "border-color 0.2s",
+          "&:hover": { borderColor: "primary.300" },
+        },
+        onClick: handleClick,
+        onDrop: handleDrop,
+        onDragOver: handleDragOver,
+        onDragLeave: handleDragLeave,
+      },
+      children ??
+        createElement(
+          "div",
+          null,
+          upload.isUploading
+            ? createElement(
+                "div",
+                null,
+                createElement(JoyTypography, { level: "body-sm" as const }, `Uploading... ${upload.progress}%`),
+                createElement(JoyLinearProgress, {
+                  determinate: true,
+                  value: upload.progress,
+                  sx: { mt: 1 },
+                }),
+              )
+            : hasError
+              ? createElement(
+                  JoyTypography,
+                  { color: "danger" as const, level: "body-sm" as const },
+                  upload.error ?? upload.validationError,
+                )
+              : createElement(
+                  JoyTypography,
+                  { level: "body-sm" as const, color: "neutral" as const },
+                  "Drop files here or click to browse",
+                ),
+        ),
+    ),
+    createElement("input", {
+      ref: inputRef,
+      type: "file",
+      accept: upload.accept,
+      multiple,
+      style: { display: "none" },
+      onChange: (e: React.ChangeEvent<HTMLInputElement>) => handleFiles(e.target.files),
+    }),
+  );
+}

--- a/packages/ui/src/joy/file-list.tsx
+++ b/packages/ui/src/joy/file-list.tsx
@@ -1,0 +1,65 @@
+import { createElement, type ReactElement } from "react";
+import JoyList from "@mui/joy/List";
+import JoyListItem from "@mui/joy/ListItem";
+import JoyListItemContent from "@mui/joy/ListItemContent";
+import JoyTypography from "@mui/joy/Typography";
+import JoyButton from "@mui/joy/Button";
+import type { FileListProps } from "../types.js";
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+/**
+ * Joy UI styled FileList.
+ */
+export function FileList({
+  files,
+  onDownload,
+}: FileListProps): ReactElement {
+  if (files.length === 0) {
+    return createElement(
+      JoyTypography,
+      { level: "body-sm" as const, color: "neutral" as const },
+      "No files",
+    );
+  }
+
+  return createElement(
+    JoyList,
+    { size: "sm" as const },
+    ...files.map((file) =>
+      createElement(
+        JoyListItem,
+        { key: file.key },
+        createElement(
+          JoyListItemContent,
+          null,
+          createElement(JoyTypography, { level: "body-sm" as const }, file.name),
+          file.size != null
+            ? createElement(
+                JoyTypography,
+                { level: "body-xs" as const, color: "neutral" as const },
+                formatBytes(file.size),
+              )
+            : null,
+        ),
+        (onDownload || file.url)
+          ? createElement(
+              JoyButton,
+              {
+                size: "sm" as const,
+                variant: "plain" as const,
+                onClick: onDownload
+                  ? () => onDownload(file)
+                  : undefined,
+                children: "↓",
+              },
+            )
+          : null,
+      ),
+    ),
+  );
+}

--- a/packages/ui/src/joy/image-preview.tsx
+++ b/packages/ui/src/joy/image-preview.tsx
@@ -1,0 +1,45 @@
+import { createElement, type ReactElement } from "react";
+import JoyAspectRatio from "@mui/joy/AspectRatio";
+import JoyTypography from "@mui/joy/Typography";
+import type { ImagePreviewProps } from "../types.js";
+
+/**
+ * Joy UI styled ImagePreview.
+ */
+export function ImagePreview({
+  fileKey,
+  src,
+  getUrl,
+  width = 200,
+  height = 200,
+  fallback,
+  alt = "Image preview",
+}: ImagePreviewProps): ReactElement {
+  const resolvedSrc = src ?? (fileKey && getUrl ? getUrl(fileKey) : null);
+
+  if (!resolvedSrc) {
+    return fallback
+      ? createElement("div", null, fallback)
+      : createElement(
+          JoyAspectRatio,
+          {
+            ratio: `${width}/${height}` as unknown as number,
+            sx: { width, borderRadius: "sm", bgcolor: "neutral.softBg" },
+          },
+          createElement(JoyTypography, { level: "body-sm" as const, color: "neutral" as const }, "No image"),
+        );
+  }
+
+  return createElement(
+    JoyAspectRatio,
+    {
+      ratio: `${width}/${height}` as unknown as number,
+      sx: { width, borderRadius: "sm", overflow: "hidden" },
+    },
+    createElement("img", {
+      src: resolvedSrc,
+      alt,
+      style: { objectFit: "cover", width: "100%", height: "100%" },
+    }),
+  );
+}


### PR DESCRIPTION
## Summary
- `DropZone` — drag-and-drop upload integrating with `@cfast/storage` `useUpload()`
- `ImagePreview` — displays images from storage key or direct src with fallback
- `FileList` — file listing with size formatting and download actions
- Joy implementations: Sheet+LinearProgress dropzone, AspectRatio preview, List file list

## Test plan
- [x] `pnpm test` — 17 new tests pass (130 total)
- [x] `pnpm typecheck` — no errors
- [x] `pnpm build` — clean

> Part 9 of 10. Depends on PR 7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)