### PR TITLE
feat(ui): PR 9 — composite views (ListView, DetailView)

### DIFF
--- a/packages/ui/src/client.ts
+++ b/packages/ui/src/client.ts
@@ -24,3 +24,5 @@ export { useColumnInference } from "./hooks/use-column-inference.js";
 export { DropZone } from "./components/drop-zone.js";
 export { ImagePreview } from "./components/image-preview.js";
 export { FileList } from "./components/file-list.js";
+export { ListView } from "./components/list-view.js";
+export { DetailView } from "./components/detail-view.js";

--- a/packages/ui/src/components/detail-view.test.tsx
+++ b/packages/ui/src/components/detail-view.test.tsx
@@ -1,0 +1,94 @@
+// @vitest-environment jsdom
+import { describe, it, expect, afterEach } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import { createElement } from "react";
+import { DetailView } from "./detail-view.js";
+
+vi.mock("./page-container.js", () => ({
+  PageContainer: ({ title, children }: { title?: string; children: unknown }) =>
+    createElement("div", { "data-testid": "page-container" },
+      title ? createElement("h1", null, title) : null,
+      children as string,
+    ),
+}));
+
+import { vi } from "vitest";
+
+afterEach(cleanup);
+
+describe("DetailView", () => {
+  it("renders title in PageContainer", () => {
+    render(
+      createElement(DetailView, {
+        title: "Post Details",
+        record: { id: 1, name: "Test" },
+        fields: ["id", "name"],
+      }),
+    );
+
+    expect(screen.getByText("Post Details")).toBeTruthy();
+  });
+
+  it("renders field labels and values", () => {
+    render(
+      createElement(DetailView, {
+        title: "Post",
+        record: { id: 1, name: "Hello World" },
+        fields: ["id", "name"],
+      }),
+    );
+
+    expect(screen.getByText("Id")).toBeTruthy();
+    expect(screen.getByText("1")).toBeTruthy();
+    expect(screen.getByText("Name")).toBeTruthy();
+    expect(screen.getByText("Hello World")).toBeTruthy();
+  });
+
+  it("infers fields from record when none specified", () => {
+    render(
+      createElement(DetailView, {
+        title: "Post",
+        record: { id: 1, title: "Test", status: "published" },
+      }),
+    );
+
+    expect(screen.getByText("Id")).toBeTruthy();
+    expect(screen.getByText("Title")).toBeTruthy();
+    expect(screen.getByText("Status")).toBeTruthy();
+  });
+
+  it("excludes fields when exclude prop is set", () => {
+    render(
+      createElement(DetailView, {
+        title: "Post",
+        record: { id: 1, title: "Test", secret: "hidden" },
+        exclude: ["secret"],
+      }),
+    );
+
+    expect(screen.getByText("Id")).toBeTruthy();
+    expect(screen.getByText("Title")).toBeTruthy();
+    expect(screen.queryByText("Secret")).toBeNull();
+  });
+
+  it("uses custom render function for fields", () => {
+    render(
+      createElement(DetailView, {
+        title: "Post",
+        record: { id: 1, status: "published" },
+        fields: [
+          "id",
+          {
+            key: "status",
+            label: "Status",
+            render: (value: unknown) =>
+              createElement("span", { "data-testid": "custom-render" }, `Status: ${value}`),
+          },
+        ],
+      }),
+    );
+
+    expect(screen.getByTestId("custom-render")).toBeTruthy();
+    expect(screen.getByText("Status: published")).toBeTruthy();
+  });
+});

--- a/packages/ui/src/components/detail-view.tsx
+++ b/packages/ui/src/components/detail-view.tsx
@@ -1,0 +1,125 @@
+import { createElement } from "react";
+import { PageContainer } from "./page-container.js";
+import { fieldForColumn } from "../fields/field-for-column.js";
+import type { DetailViewProps, ColumnDef, ColumnShorthand } from "../types.js";
+
+function normalizeFields<T>(
+  fields: ColumnShorthand<T>[] | undefined,
+): ColumnDef<T>[] {
+  if (!fields) return [];
+  return fields.map((col) => {
+    if (typeof col === "string") {
+      return {
+        key: col,
+        label: col
+          .replace(/([A-Z])/g, " $1")
+          .replace(/^./, (s) => s.toUpperCase())
+          .trim(),
+      };
+    }
+    return col;
+  });
+}
+
+/**
+ * Composite DetailView — displays a single record's fields in a two-column grid.
+ * Composes PageContainer + TypedField rendering.
+ */
+export function DetailView<T = unknown>({
+  title,
+  table,
+  record,
+  fields: fieldsProp,
+  exclude,
+  breadcrumb,
+}: DetailViewProps<T>) {
+  const fields = normalizeFields(fieldsProp);
+
+  // If no fields specified but table is provided, infer from table
+  const displayFields =
+    fields.length > 0
+      ? fields
+      : inferFieldsFromRecord(record, exclude);
+
+  return createElement(
+    PageContainer,
+    {
+      title,
+      breadcrumb,
+      children: createElement(
+        "div",
+        {
+          style: {
+            display: "grid",
+            gridTemplateColumns: "1fr 1fr",
+            gap: "16px",
+          },
+        },
+        ...displayFields.map((field) => {
+          const value = (record as Record<string, unknown>)[field.key];
+          const FieldComponent = field.render
+            ? null
+            : resolveFieldComponent(field.key, table);
+
+          return createElement(
+            "div",
+            { key: field.key },
+            createElement(
+              "div",
+              {
+                style: {
+                  fontSize: "0.85em",
+                  color: "#666",
+                  marginBottom: "4px",
+                  fontWeight: 600,
+                },
+              },
+              field.label ?? field.key,
+            ),
+            createElement(
+              "div",
+              null,
+              field.render
+                ? field.render(value, record)
+                : FieldComponent
+                  ? createElement(FieldComponent, { value })
+                  : String(value ?? "—"),
+            ),
+          );
+        }),
+      ),
+    },
+  );
+}
+
+function inferFieldsFromRecord<T>(
+  record: T,
+  exclude?: string[],
+): ColumnDef<T>[] {
+  if (!record || typeof record !== "object") return [];
+
+  return Object.keys(record as Record<string, unknown>)
+    .filter((key) => !exclude || !exclude.includes(key))
+    .map((key) => ({
+      key,
+      label: key
+        .replace(/([A-Z])/g, " $1")
+        .replace(/^./, (s) => s.toUpperCase())
+        .trim(),
+    }));
+}
+
+function resolveFieldComponent(
+  _key: string,
+  table: unknown,
+): ReturnType<typeof fieldForColumn> | null {
+  if (!table || typeof table !== "object") return null;
+
+  const col = (table as Record<string, unknown>)[_key];
+  if (!col || typeof col !== "object" || !("dataType" in col) || !("name" in col)) {
+    return null;
+  }
+
+  const meta = col as { dataType: string; name: string };
+  return fieldForColumn(meta);
+}

--- a/packages/ui/src/components/list-view.test.tsx
+++ b/packages/ui/src/components/list-view.test.tsx
@@ -1,0 +1,152 @@
+// @vitest-environment jsdom
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { render, screen, cleanup, fireEvent } from "@testing-library/react";
+import { createElement } from "react";
+import { ListView } from "./list-view.js";
+
+// Mock all child components to isolate ListView logic
+vi.mock("./page-container.js", () => ({
+  PageContainer: ({ title, actions, children }: { title?: string; actions?: unknown; children: unknown }) =>
+    createElement("div", { "data-testid": "page-container" },
+      title ? createElement("h1", null, title) : null,
+      actions ? createElement("div", { "data-testid": "actions-slot" }, actions as string) : null,
+      children as string,
+    ),
+}));
+
+vi.mock("./data-table.js", () => ({
+  DataTable: ({ data }: { data: { items: unknown[] } }) =>
+    createElement("div", { "data-testid": "data-table" }, `${data.items.length} rows`),
+}));
+
+vi.mock("./filter-bar.js", () => ({
+  FilterBar: () => createElement("div", { "data-testid": "filter-bar" }),
+}));
+
+vi.mock("./bulk-action-bar.js", () => ({
+  BulkActionBar: ({ selectedCount }: { selectedCount: number }) =>
+    selectedCount > 0
+      ? createElement("div", { "data-testid": "bulk-action-bar" }, `${selectedCount} selected`)
+      : null,
+}));
+
+vi.mock("./empty-state.js", () => ({
+  EmptyState: ({ title }: { title: string }) =>
+    createElement("div", { "data-testid": "empty-state" }, title),
+}));
+
+vi.mock("./action-button.js", () => ({
+  ActionButton: ({ children }: { children: unknown }) =>
+    createElement("button", { "data-testid": "create-button" }, children as string),
+}));
+
+vi.mock("react-router", () => ({
+  useSearchParams: () => [new URLSearchParams()],
+  useNavigate: () => vi.fn(),
+  useLocation: () => ({ pathname: "/test" }),
+}));
+
+afterEach(cleanup);
+
+describe("ListView", () => {
+  it("renders title in PageContainer", () => {
+    render(
+      createElement(ListView, {
+        title: "Posts",
+        data: { items: [{ id: 1, name: "Test" }] },
+        columns: ["name"],
+      }),
+    );
+
+    expect(screen.getByText("Posts")).toBeTruthy();
+  });
+
+  it("renders DataTable with data", () => {
+    render(
+      createElement(ListView, {
+        title: "Posts",
+        data: { items: [{ id: 1 }, { id: 2 }] },
+        columns: ["id"],
+      }),
+    );
+
+    expect(screen.getByTestId("data-table")).toBeTruthy();
+    expect(screen.getByText("2 rows")).toBeTruthy();
+  });
+
+  it("renders EmptyState when no data", () => {
+    render(
+      createElement(ListView, {
+        title: "Posts",
+        data: { items: [], isLoading: false },
+      }),
+    );
+
+    expect(screen.getByTestId("empty-state")).toBeTruthy();
+  });
+
+  it("renders FilterBar when filters provided", () => {
+    render(
+      createElement(ListView, {
+        title: "Posts",
+        data: { items: [{ id: 1 }] },
+        filters: [{ column: "status", type: "select" as const }],
+      }),
+    );
+
+    expect(screen.getByTestId("filter-bar")).toBeTruthy();
+  });
+
+  it("renders pagination controls for offset pagination", () => {
+    render(
+      createElement(ListView, {
+        title: "Posts",
+        data: {
+          items: [{ id: 1 }],
+          totalPages: 5,
+          currentPage: 2,
+          goToPage: vi.fn(),
+        },
+        columns: ["id"],
+      }),
+    );
+
+    expect(screen.getByText("Page 2 of 5")).toBeTruthy();
+    expect(screen.getByText("Previous")).toBeTruthy();
+    expect(screen.getByText("Next")).toBeTruthy();
+  });
+
+  it("renders load more button for cursor pagination", () => {
+    const loadMore = vi.fn();
+    render(
+      createElement(ListView, {
+        title: "Posts",
+        data: {
+          items: [{ id: 1 }],
+          hasMore: true,
+          loadMore,
+        },
+        columns: ["id"],
+      }),
+    );
+
+    const button = screen.getByText("Load more");
+    expect(button).toBeTruthy();
+    fireEvent.click(button);
+    expect(loadMore).toHaveBeenCalled();
+  });
+
+  it("renders create button when createAction provided", () => {
+    render(
+      createElement(ListView, {
+        title: "Posts",
+        data: { items: [{ id: 1 }] },
+        createAction: { _brand: "ActionClientDescriptor" as const, actionNames: ["create"], permissionsKey: "test" },
+        createLabel: "New Post",
+      }),
+    );
+
+    expect(screen.getByTestId("create-button")).toBeTruthy();
+    expect(screen.getByText("New Post")).toBeTruthy();
+  });
+});

--- a/packages/ui/src/components/list-view.tsx
+++ b/packages/ui/src/components/list-view.tsx
@@ -1,0 +1,147 @@
+import { createElement, useState, useCallback } from "react";
+import { PageContainer } from "./page-container.js";
+import { DataTable } from "./data-table.js";
+import { FilterBar } from "./filter-bar.js";
+import { BulkActionBar } from "./bulk-action-bar.js";
+import { EmptyState } from "./empty-state.js";
+import { ActionButton } from "./action-button.js";
+import type { ListViewProps, BulkAction, ColumnShorthand } from "../types.js";
+
+/**
+ * Composite ListView — composes PageContainer, FilterBar, DataTable,
+ * EmptyState, BulkActionBar, and pagination controls.
+ */
+export function ListView<T = unknown>({
+  title,
+  data,
+  table: _table,
+  columns,
+  actions: _actions,
+  filters,
+  searchable,
+  createAction,
+  createLabel = "Create",
+  selectable = false,
+  bulkActions,
+  breadcrumb,
+}: ListViewProps<T>) {
+  const [selectedRows, setSelectedRows] = useState<T[]>([]);
+
+  const handleBulkAction = useCallback(
+    (action: BulkAction) => {
+      if (action.handler) {
+        action.handler(selectedRows);
+      }
+    },
+    [selectedRows],
+  );
+
+  const clearSelection = useCallback(() => {
+    setSelectedRows([]);
+  }, []);
+
+  const createButton = createAction
+    ? createElement(ActionButton, {
+        action: createAction,
+        children: createLabel,
+        variant: "solid",
+        color: "primary",
+      })
+    : null;
+
+  return createElement(
+    PageContainer,
+    {
+      title,
+      breadcrumb,
+      actions: createButton,
+      children: createElement(
+        "div",
+        null,
+        // Filters
+        filters && filters.length > 0
+          ? createElement(FilterBar, {
+              filters,
+              searchable,
+            })
+          : null,
+        // Bulk actions
+        selectable && bulkActions && bulkActions.length > 0
+          ? createElement(BulkActionBar, {
+              selectedCount: selectedRows.length,
+              actions: bulkActions,
+              onAction: handleBulkAction,
+              onClearSelection: clearSelection,
+            })
+          : null,
+        // Data table or empty state
+        data.items.length === 0 && !data.isLoading
+          ? createElement(EmptyState, {
+              title: `No ${title.toLowerCase()} found`,
+              description: filters ? "Try adjusting your filters" : undefined,
+              createAction,
+              createLabel,
+            })
+          : createElement(DataTable, {
+              data,
+              columns: columns as ColumnShorthand<unknown>[],
+              selectable,
+              selectedRows: selectable ? (selectedRows as unknown[]) : undefined,
+              onSelectionChange: selectable
+                ? (rows: unknown[]) => setSelectedRows(rows as T[])
+                : undefined,
+            }),
+        // Pagination controls
+        data.totalPages && data.totalPages > 1 && data.goToPage
+          ? createElement(
+              "div",
+              {
+                style: {
+                  display: "flex",
+                  justifyContent: "center",
+                  gap: "8px",
+                  marginTop: "16px",
+                },
+              },
+              createElement(
+                "button",
+                {
+                  disabled: data.currentPage === 1,
+                  onClick: () => data.goToPage?.(Math.max(1, (data.currentPage ?? 1) - 1)),
+                },
+                "Previous",
+              ),
+              createElement(
+                "span",
+                null,
+                `Page ${data.currentPage ?? 1} of ${data.totalPages}`,
+              ),
+              createElement(
+                "button",
+                {
+                  disabled: data.currentPage === data.totalPages,
+                  onClick: () =>
+                    data.goToPage?.(
+                      Math.min(data.totalPages ?? 1, (data.currentPage ?? 1) + 1),
+                    ),
+                },
+                "Next",
+              ),
+            )
+          : null,
+        // Load more (cursor-based)
+        data.hasMore && data.loadMore
+          ? createElement(
+              "div",
+              { style: { textAlign: "center" as const, marginTop: "16px" } },
+              createElement(
+                "button",
+                { onClick: data.loadMore },
+                "Load more",
+              ),
+            )
+          : null,
+      ),
+    },
+  );
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -36,6 +36,10 @@ export { DropZone } from "./components/drop-zone.js";
 export { ImagePreview } from "./components/image-preview.js";
 export { FileList } from "./components/file-list.js";
 
+// Composite views
+export { ListView } from "./components/list-view.js";
+export { DetailView } from "./components/detail-view.js";
+
 // Hooks — data
 export { useColumnInference } from "./hooks/use-column-inference.js";
 

--- a/packages/ui/src/joy.ts
+++ b/packages/ui/src/joy.ts
@@ -25,6 +25,10 @@ export { DropZone } from "./joy/drop-zone.js";
 export { ImagePreview } from "./joy/image-preview.js";
 export { FileList } from "./joy/file-list.js";
 
+// Composite views
+export { ListView } from "./joy/list-view.js";
+export { DetailView } from "./joy/detail-view.js";
+
 // Utilities
 export { AvatarWithInitials } from "./joy/avatar-with-initials.js";
 export { RoleBadge } from "./joy/role-badge.js";

--- a/packages/ui/src/joy/detail-view.tsx
+++ b/packages/ui/src/joy/detail-view.tsx
@@ -1,0 +1,117 @@
+import { createElement, type ReactElement } from "react";
+import JoyGrid from "@mui/joy/Grid";
+import JoyTypography from "@mui/joy/Typography";
+import { PageContainer } from "./page-container.js";
+import { fieldForColumn } from "../fields/field-for-column.js";
+import type { DetailViewProps, ColumnDef, ColumnShorthand } from "../types.js";
+
+function normalizeFields<T>(
+  fields: ColumnShorthand<T>[] | undefined,
+): ColumnDef<T>[] {
+  if (!fields) return [];
+  return fields.map((col) => {
+    if (typeof col === "string") {
+      return {
+        key: col,
+        label: col
+          .replace(/([A-Z])/g, " $1")
+          .replace(/^./, (s) => s.toUpperCase())
+          .trim(),
+      };
+    }
+    return col;
+  });
+}
+
+/**
+ * Joy UI styled DetailView — two-column grid of record fields.
+ */
+export function DetailView<T = unknown>({
+  title,
+  table,
+  record,
+  fields: fieldsProp,
+  exclude,
+  breadcrumb,
+}: DetailViewProps<T>): ReactElement {
+  const fields = normalizeFields(fieldsProp);
+
+  const displayFields =
+    fields.length > 0
+      ? fields
+      : inferFieldsFromRecord(record, exclude);
+
+  return createElement(
+    PageContainer,
+    {
+      title,
+      breadcrumb,
+      children: createElement(
+        JoyGrid,
+        { container: true, spacing: 2 },
+        ...displayFields.map((field) => {
+          const value = (record as Record<string, unknown>)[field.key];
+          const FieldComponent = field.render
+            ? null
+            : resolveFieldComponent(field.key, table);
+
+          return createElement(
+            JoyGrid,
+            { key: field.key, xs: 12, md: 6 },
+            createElement(
+              JoyTypography,
+              {
+                level: "body-xs" as const,
+                textTransform: "uppercase" as const,
+                fontWeight: "lg" as const,
+                mb: 0.5,
+              },
+              field.label ?? field.key,
+            ),
+            createElement(
+              "div",
+              null,
+              field.render
+                ? field.render(value, record)
+                : FieldComponent
+                  ? createElement(FieldComponent, { value })
+                  : String(value ?? "—"),
+            ),
+          );
+        }),
+      ),
+    },
+  );
+}
+
+function inferFieldsFromRecord<T>(
+  record: T,
+  exclude?: string[],
+): ColumnDef<T>[] {
+  if (!record || typeof record !== "object") return [];
+
+  return Object.keys(record as Record<string, unknown>)
+    .filter((key) => !exclude || !exclude.includes(key))
+    .map((key) => ({
+      key,
+      label: key
+        .replace(/([A-Z])/g, " $1")
+        .replace(/^./, (s) => s.toUpperCase())
+        .trim(),
+    }));
+}
+
+function resolveFieldComponent(
+  _key: string,
+  table: unknown,
+): ReturnType<typeof fieldForColumn> | null {
+  if (!table || typeof table !== "object") return null;
+
+  const col = (table as Record<string, unknown>)[_key];
+  if (!col || typeof col !== "object" || !("dataType" in col) || !("name" in col)) {
+    return null;
+  }
+
+  const meta = col as { dataType: string; name: string };
+  return fieldForColumn(meta);
+}

--- a/packages/ui/src/joy/list-view.tsx
+++ b/packages/ui/src/joy/list-view.tsx
@@ -1,0 +1,135 @@
+import { createElement, useState, useCallback, type ReactElement } from "react";
+import JoyButton from "@mui/joy/Button";
+import JoyStack from "@mui/joy/Stack";
+import JoyTypography from "@mui/joy/Typography";
+import { PageContainer } from "./page-container.js";
+import { DataTable } from "./data-table.js";
+import { FilterBar } from "./filter-bar.js";
+import { BulkActionBar } from "./bulk-action-bar.js";
+import { EmptyState } from "./empty-state.js";
+import { ActionButton } from "./action-button.js";
+import type { ListViewProps, BulkAction, ColumnShorthand } from "../types.js";
+
+/**
+ * Joy UI styled ListView — full page list with filters, table, and pagination.
+ */
+export function ListView<T = unknown>({
+  title,
+  data,
+  table: _table,
+  columns,
+  actions: _actions,
+  filters,
+  searchable,
+  createAction,
+  createLabel = "Create",
+  selectable = false,
+  bulkActions,
+  breadcrumb,
+}: ListViewProps<T>): ReactElement {
+  const [selectedRows, setSelectedRows] = useState<T[]>([]);
+
+  const handleBulkAction = useCallback(
+    (action: BulkAction) => {
+      if (action.handler) {
+        action.handler(selectedRows);
+      }
+    },
+    [selectedRows],
+  );
+
+  const clearSelection = useCallback(() => {
+    setSelectedRows([]);
+  }, []);
+
+  const createButton = createAction
+    ? createElement(ActionButton, {
+        action: createAction,
+        children: createLabel,
+        variant: "solid",
+        color: "primary",
+      })
+    : null;
+
+  return createElement(
+    PageContainer,
+    {
+      title,
+      breadcrumb,
+      actions: createButton,
+      children: createElement(
+        JoyStack,
+        { spacing: 2 },
+        // Filters
+        filters && filters.length > 0
+          ? createElement(FilterBar, { filters, searchable })
+          : null,
+        // Bulk actions
+        selectable && bulkActions && bulkActions.length > 0
+          ? createElement(BulkActionBar, {
+              selectedCount: selectedRows.length,
+              actions: bulkActions,
+              onAction: handleBulkAction,
+              onClearSelection: clearSelection,
+            })
+          : null,
+        // Data table or empty state
+        data.items.length === 0 && !data.isLoading
+          ? createElement(EmptyState, {
+              title: `No ${title.toLowerCase()} found`,
+              description: filters ? "Try adjusting your filters" : undefined,
+              createAction,
+              createLabel,
+            })
+          : createElement(DataTable, {
+              data,
+              columns: columns as ColumnShorthand<unknown>[],
+              selectable,
+              selectedRows: selectable ? (selectedRows as unknown[]) : undefined,
+              onSelectionChange: selectable
+                ? (rows: unknown[]) => setSelectedRows(rows as T[])
+                : undefined,
+            }),
+        // Offset pagination
+        data.totalPages && data.totalPages > 1 && data.goToPage
+          ? createElement(
+              JoyStack,
+              { direction: "row" as const, justifyContent: "center", alignItems: "center", spacing: 2 },
+              createElement(JoyButton, {
+                size: "sm" as const,
+                variant: "outlined" as const,
+                disabled: data.currentPage === 1,
+                onClick: () => data.goToPage?.(Math.max(1, (data.currentPage ?? 1) - 1)),
+                children: "Previous",
+              }),
+              createElement(
+                JoyTypography,
+                { level: "body-sm" as const },
+                `Page ${data.currentPage ?? 1} of ${data.totalPages}`,
+              ),
+              createElement(JoyButton, {
+                size: "sm" as const,
+                variant: "outlined" as const,
+                disabled: data.currentPage === data.totalPages,
+                onClick: () =>
+                  data.goToPage?.(Math.min(data.totalPages ?? 1, (data.currentPage ?? 1) + 1)),
+                children: "Next",
+              }),
+            )
+          : null,
+        // Cursor-based load more
+        data.hasMore && data.loadMore
+          ? createElement(
+              JoyStack,
+              { alignItems: "center" },
+              createElement(JoyButton, {
+                variant: "soft" as const,
+                onClick: data.loadMore,
+                children: "Load more",
+              }),
+            )
+          : null,
+      ),
+    },
+  );
+}


### PR DESCRIPTION
## Summary
- `ListView` — composes PageContainer, FilterBar, DataTable, EmptyState, BulkActionBar, and pagination (offset + cursor)
- `DetailView` — two-column grid of record fields with auto-inference from Drizzle table metadata
- Joy implementations: Stack-based layout, Grid detail view, Button pagination

## Test plan
- [x] `pnpm test` — 12 new tests pass (142 total)
- [x] `pnpm typecheck` — no errors
- [x] `pnpm build` — clean

> Part 10 of 10. Final PR in the `@cfast/ui` stack. Depends on PR 8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)