### PR TITLE
ci: turbo best practices for caching and parallelism

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,10 +12,12 @@ concurrency:
 
 jobs:
   ci:
-    name: Typecheck & Lint
+    name: Build, Typecheck, Lint & Test
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: ${{ github.event_name == 'pull_request' && 0 || 1 }}
 
       - uses: pnpm/action-setup@v4
 
@@ -26,11 +28,17 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
-      - run: pnpm build
+      - name: Cache turbo
+        uses: actions/cache@v4
+        with:
+          path: .turbo
+          key: turbo-${{ runner.os }}-${{ github.sha }}
+          restore-keys: turbo-${{ runner.os }}-
 
-      - run: pnpm typecheck
-
-      - run: pnpm lint
+      - name: Build, typecheck, lint & test
+        run: >
+          pnpm turbo build typecheck lint test
+          ${{ github.event_name == 'pull_request' && '--filter=...[origin/main]' || '' }}
 
       - run: pnpm test
 
@@ -53,6 +61,13 @@ jobs:
           cache: pnpm
 
       - run: pnpm install --frozen-lockfile
+
+      - name: Restore turbo cache
+        uses: actions/cache@v4
+        with:
+          path: .turbo
+          key: turbo-${{ runner.os }}-${{ github.sha }}
+          restore-keys: turbo-${{ runner.os }}-
 
       - run: pnpm build
 

--- a/turbo.json
+++ b/turbo.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://turbo.build/schema.json",
+  "globalEnv": ["NODE_ENV"],
   "tasks": {
     "build": {
       "dependsOn": ["^build"],
@@ -10,13 +11,17 @@
       "persistent": true
     },
     "lint": {
-      "dependsOn": ["^build"]
+      "dependsOn": ["^build"],
+      "inputs": ["src/**", "*.config.*", "tsconfig*.json"]
     },
     "typecheck": {
-      "dependsOn": ["^build"]
+      "dependsOn": ["^build"],
+      "inputs": ["src/**", "tsconfig*.json"]
     },
     "test": {
-      "dependsOn": ["^build"]
+      "dependsOn": ["^build"],
+      "inputs": ["src/**", "test/**", "*.config.*", "tsconfig*.json"],
+      "env": ["CI"]
     },
     "clean": {
       "cache": false


### PR DESCRIPTION
## Summary
- Add `inputs`, `env`, and `globalEnv` declarations to `turbo.json` for more accurate cache keys
- Consolidate four separate turbo commands into a single invocation for better task parallelism
- Add `actions/cache` to persist turbo's local cache between CI runs (shared with E2E job)
- Use `--filter=...[origin/main]` on PRs to only build/test affected packages
- Conditional `fetch-depth` — full history only on PRs where the filter needs it

## Test plan
- [ ] Verify CI passes on this PR (proves the workflow syntax is correct)
- [ ] Check turbo cache hits on a re-run of the same commit
- [ ] Open a PR that only touches one package and verify turbo skips unaffected packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)