### PR TITLE
feat(ui): PR 4 — TypedField components + fieldForColumn()

### DIFF
--- a/packages/ui/src/fields/__tests__/boolean-field.test.tsx
+++ b/packages/ui/src/fields/__tests__/boolean-field.test.tsx
@@ -1,0 +1,32 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import { createElement } from "react";
+import { BooleanField } from "../boolean-field.js";
+
+afterEach(cleanup);
+
+describe("BooleanField", () => {
+  it("renders em-dash for null value", () => {
+    render(createElement(BooleanField, { value: null }));
+    expect(screen.getByText("—")).toBeTruthy();
+  });
+
+  it("renders true label when value is true", () => {
+    render(createElement(BooleanField, { value: true }));
+    expect(screen.getByText("Yes")).toBeTruthy();
+  });
+
+  it("renders false label when value is false", () => {
+    render(createElement(BooleanField, { value: false }));
+    expect(screen.getByText("No")).toBeTruthy();
+  });
+
+  it("renders custom labels", () => {
+    render(createElement(BooleanField, {
+      value: true,
+      trueLabel: "Published",
+      falseLabel: "Draft",
+    }));
+    expect(screen.getByText("Published")).toBeTruthy();
+  });
+});

--- a/packages/ui/src/fields/__tests__/date-field.test.tsx
+++ b/packages/ui/src/fields/__tests__/date-field.test.tsx
@@ -1,0 +1,38 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import { createElement } from "react";
+import { DateField } from "../date-field.js";
+
+afterEach(cleanup);
+
+describe("DateField", () => {
+  it("renders em-dash for null value", () => {
+    render(createElement(DateField, { value: null }));
+    expect(screen.getByText("—")).toBeTruthy();
+  });
+
+  it("formats date in short format by default", () => {
+    render(createElement(DateField, { value: new Date("2026-03-11T00:00:00Z"), locale: "en-US" }));
+    const time = document.querySelector("time");
+    expect(time).toBeTruthy();
+    expect(time?.textContent).toMatch(/Mar/);
+  });
+
+  it("formats date in long format", () => {
+    render(createElement(DateField, { value: "2026-03-11", format: "long", locale: "en-US" }));
+    expect(screen.getByText(/March/)).toBeTruthy();
+  });
+
+  it("handles invalid date", () => {
+    render(createElement(DateField, { value: "not-a-date" }));
+    expect(screen.getByText("Invalid date")).toBeTruthy();
+  });
+
+  it("formats relative dates", () => {
+    const now = new Date();
+    render(createElement(DateField, { value: now, format: "relative" }));
+    // "now" or "0 seconds ago" or similar
+    const time = document.querySelector("time");
+    expect(time).toBeTruthy();
+  });
+});

--- a/packages/ui/src/fields/__tests__/field-for-column.test.ts
+++ b/packages/ui/src/fields/__tests__/field-for-column.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from "vitest";
+import { fieldForColumn } from "../field-for-column.js";
+import { DateField } from "../date-field.js";
+import { BooleanField } from "../boolean-field.js";
+import { NumberField } from "../number-field.js";
+import { TextField } from "../text-field.js";
+import { EmailField } from "../email-field.js";
+import { JsonField } from "../json-field.js";
+
+describe("fieldForColumn", () => {
+  it("maps timestamp to DateField", () => {
+    expect(fieldForColumn({ dataType: "timestamp", name: "createdAt" })).toBe(DateField);
+  });
+
+  it("maps boolean to BooleanField", () => {
+    expect(fieldForColumn({ dataType: "boolean", name: "published" })).toBe(BooleanField);
+  });
+
+  it("maps integer to NumberField", () => {
+    expect(fieldForColumn({ dataType: "integer", name: "count" })).toBe(NumberField);
+  });
+
+  it("maps real to NumberField", () => {
+    expect(fieldForColumn({ dataType: "real", name: "price" })).toBe(NumberField);
+  });
+
+  it("maps email column name to EmailField", () => {
+    expect(fieldForColumn({ dataType: "text", name: "email" })).toBe(EmailField);
+  });
+
+  it("maps json to JsonField", () => {
+    expect(fieldForColumn({ dataType: "json", name: "metadata" })).toBe(JsonField);
+  });
+
+  it("defaults to TextField for text type", () => {
+    expect(fieldForColumn({ dataType: "text", name: "title" })).toBe(TextField);
+  });
+});

--- a/packages/ui/src/fields/__tests__/number-field.test.tsx
+++ b/packages/ui/src/fields/__tests__/number-field.test.tsx
@@ -1,0 +1,28 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import { createElement } from "react";
+import { NumberField } from "../number-field.js";
+
+afterEach(cleanup);
+
+describe("NumberField", () => {
+  it("renders em-dash for null value", () => {
+    render(createElement(NumberField, { value: null }));
+    expect(screen.getByText("—")).toBeTruthy();
+  });
+
+  it("formats number with default locale", () => {
+    render(createElement(NumberField, { value: 1234.5, locale: "en-US" }));
+    expect(screen.getByText("1,234.5")).toBeTruthy();
+  });
+
+  it("formats currency", () => {
+    render(createElement(NumberField, { value: 42.99, currency: "USD", locale: "en-US" }));
+    expect(screen.getByText("$42.99")).toBeTruthy();
+  });
+
+  it("formats with fixed decimals", () => {
+    render(createElement(NumberField, { value: 3, decimals: 2, locale: "en-US" }));
+    expect(screen.getByText("3.00")).toBeTruthy();
+  });
+});

--- a/packages/ui/src/fields/__tests__/text-field.test.tsx
+++ b/packages/ui/src/fields/__tests__/text-field.test.tsx
@@ -1,0 +1,28 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import { createElement } from "react";
+import { TextField } from "../text-field.js";
+
+afterEach(cleanup);
+
+describe("TextField", () => {
+  it("renders em-dash for null value", () => {
+    render(createElement(TextField, { value: null }));
+    expect(screen.getByText("—")).toBeTruthy();
+  });
+
+  it("renders text as-is", () => {
+    render(createElement(TextField, { value: "Hello World" }));
+    expect(screen.getByText("Hello World")).toBeTruthy();
+  });
+
+  it("truncates with ellipsis when maxLength exceeded", () => {
+    render(createElement(TextField, { value: "A long text", maxLength: 6 }));
+    expect(screen.getByText("A long…")).toBeTruthy();
+  });
+
+  it("shows full text in title when truncated", () => {
+    render(createElement(TextField, { value: "A long text value", maxLength: 6 }));
+    expect(screen.getByText("A long…").getAttribute("title")).toBe("A long text value");
+  });
+});

--- a/packages/ui/src/fields/boolean-field.tsx
+++ b/packages/ui/src/fields/boolean-field.tsx
@@ -1,0 +1,24 @@
+import { createElement } from "react";
+import { useComponent } from "../plugin.js";
+import type { BooleanFieldProps } from "../types.js";
+
+export function BooleanField({
+  value,
+  trueLabel = "Yes",
+  falseLabel = "No",
+  trueColor = "success",
+  falseColor = "neutral",
+}: BooleanFieldProps) {
+  const Chip = useComponent("chip");
+
+  if (value == null) {
+    return createElement("span", null, "—");
+  }
+
+  return createElement(Chip, {
+    children: value ? trueLabel : falseLabel,
+    color: (value ? trueColor : falseColor) as "success" | "neutral" | "danger" | "primary" | "warning",
+    variant: "soft",
+    size: "sm",
+  });
+}

--- a/packages/ui/src/fields/date-field.tsx
+++ b/packages/ui/src/fields/date-field.tsx
@@ -1,0 +1,62 @@
+import { createElement } from "react";
+import type { DateFieldProps } from "../types.js";
+
+const rtf = new Intl.RelativeTimeFormat("en", { numeric: "auto" });
+
+function getRelativeTime(date: Date): string {
+  const now = Date.now();
+  const diffMs = date.getTime() - now;
+  const diffSec = Math.round(diffMs / 1000);
+  const diffMin = Math.round(diffSec / 60);
+  const diffHour = Math.round(diffMin / 60);
+  const diffDay = Math.round(diffHour / 24);
+
+  if (Math.abs(diffSec) < 60) return rtf.format(diffSec, "second");
+  if (Math.abs(diffMin) < 60) return rtf.format(diffMin, "minute");
+  if (Math.abs(diffHour) < 24) return rtf.format(diffHour, "hour");
+  if (Math.abs(diffDay) < 30) return rtf.format(diffDay, "day");
+
+  const diffMonth = Math.round(diffDay / 30);
+  if (Math.abs(diffMonth) < 12) return rtf.format(diffMonth, "month");
+
+  return rtf.format(Math.round(diffDay / 365), "year");
+}
+
+function formatDate(date: Date, format: DateFieldProps["format"], locale: string): string {
+  switch (format) {
+    case "relative":
+      return getRelativeTime(date);
+    case "long":
+      return new Intl.DateTimeFormat(locale, {
+        dateStyle: "long",
+      }).format(date);
+    case "datetime":
+      return new Intl.DateTimeFormat(locale, {
+        dateStyle: "medium",
+        timeStyle: "short",
+      }).format(date);
+    case "short":
+    default:
+      return new Intl.DateTimeFormat(locale, {
+        dateStyle: "medium",
+      }).format(date);
+  }
+}
+
+export function DateField({
+  value,
+  format = "short",
+  locale = "en",
+}: DateFieldProps) {
+  if (value == null) {
+    return createElement("span", null, "—");
+  }
+
+  const date = value instanceof Date ? value : new Date(value);
+
+  if (Number.isNaN(date.getTime())) {
+    return createElement("span", null, "Invalid date");
+  }
+
+  return createElement("time", { dateTime: date.toISOString() }, formatDate(date, format, locale));
+}

--- a/packages/ui/src/fields/email-field.tsx
+++ b/packages/ui/src/fields/email-field.tsx
@@ -1,0 +1,10 @@
+import { createElement } from "react";
+import type { EmailFieldProps } from "../types.js";
+
+export function EmailField({ value }: EmailFieldProps) {
+  if (value == null) {
+    return createElement("span", null, "—");
+  }
+
+  return createElement("a", { href: `mailto:${value}` }, value);
+}

--- a/packages/ui/src/fields/field-for-column.ts
+++ b/packages/ui/src/fields/field-for-column.ts
@@ -1,0 +1,72 @@
+import type { ComponentType } from "react";
+import type { BaseFieldProps } from "../types.js";
+import { DateField } from "./date-field.js";
+import { BooleanField } from "./boolean-field.js";
+import { NumberField } from "./number-field.js";
+import { TextField } from "./text-field.js";
+import { EmailField } from "./email-field.js";
+import { JsonField } from "./json-field.js";
+
+type ColumnMeta = {
+  dataType: string;
+  name: string;
+};
+
+/**
+ * Maps a Drizzle column's metadata to the appropriate TypedField component.
+ *
+ * Uses `getTableColumns(table)` from drizzle-orm to get column metadata,
+ * then maps the `dataType` to a field component.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function fieldForColumn(column: ColumnMeta): ComponentType<any> {
+  const { dataType, name } = column;
+  const dt = dataType.toLowerCase();
+
+  // Boolean types
+  if (dt === "boolean" || dt === "integer" && name.startsWith("is")) {
+    return BooleanField;
+  }
+
+  // Date/timestamp types
+  if (dt.includes("timestamp") || dt.includes("date") || dt.includes("datetime")) {
+    return DateField;
+  }
+
+  // Numeric types
+  if (dt === "integer" || dt === "real" || dt === "numeric" || dt.includes("int") || dt.includes("float") || dt.includes("double") || dt.includes("decimal")) {
+    return NumberField;
+  }
+
+  // Email heuristic
+  if (name === "email" || name.endsWith("Email")) {
+    return EmailField;
+  }
+
+  // JSON types
+  if (dt === "json" || dt === "jsonb" || dt === "blob") {
+    return JsonField;
+  }
+
+  // Default to text
+  return TextField;
+}
+
+/**
+ * Given a Drizzle table, returns a map of column names to field components.
+ */
+export function fieldsForTable(
+  table: { [Symbol.iterator]?: never } & Record<string, unknown>,
+): Record<string, ComponentType<BaseFieldProps & { value: unknown }>> {
+  // Use drizzle-orm's getTableColumns if available
+  // For now, we do a duck-type check for the column structure
+  const result: Record<string, ComponentType<BaseFieldProps & { value: unknown }>> = {};
+
+  for (const [key, col] of Object.entries(table)) {
+    if (col && typeof col === "object" && "dataType" in col && "name" in col) {
+      result[key] = fieldForColumn(col as ColumnMeta);
+    }
+  }
+
+  return result;
+}

--- a/packages/ui/src/fields/file-field.tsx
+++ b/packages/ui/src/fields/file-field.tsx
@@ -1,0 +1,23 @@
+import { createElement } from "react";
+import type { FileFieldProps } from "../types.js";
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+export function FileField({
+  value,
+  fileName,
+  fileSize,
+}: FileFieldProps) {
+  if (value == null) {
+    return createElement("span", null, "—");
+  }
+
+  const name = fileName ?? value;
+  const sizeStr = fileSize != null ? ` (${formatBytes(fileSize)})` : "";
+
+  return createElement("span", null, `📄 ${name}${sizeStr}`);
+}

--- a/packages/ui/src/fields/image-field.tsx
+++ b/packages/ui/src/fields/image-field.tsx
@@ -1,0 +1,21 @@
+import { createElement } from "react";
+import type { ImageFieldProps } from "../types.js";
+
+export function ImageField({
+  value,
+  width = 80,
+  height = 60,
+  alt = "",
+}: ImageFieldProps) {
+  if (value == null) {
+    return createElement("span", null, "—");
+  }
+
+  return createElement("img", {
+    src: value,
+    alt,
+    width,
+    height,
+    style: { objectFit: "cover" as const, borderRadius: "4px" },
+  });
+}

--- a/packages/ui/src/fields/index.ts
+++ b/packages/ui/src/fields/index.ts
@@ -1,0 +1,11 @@
+export { DateField } from "./date-field.js";
+export { BooleanField } from "./boolean-field.js";
+export { NumberField } from "./number-field.js";
+export { TextField } from "./text-field.js";
+export { EmailField } from "./email-field.js";
+export { UrlField } from "./url-field.js";
+export { ImageField } from "./image-field.js";
+export { FileField } from "./file-field.js";
+export { RelationField } from "./relation-field.js";
+export { JsonField } from "./json-field.js";
+export { fieldForColumn, fieldsForTable } from "./field-for-column.js";

--- a/packages/ui/src/fields/json-field.tsx
+++ b/packages/ui/src/fields/json-field.tsx
@@ -1,0 +1,45 @@
+import { createElement, useState } from "react";
+import type { JsonFieldProps } from "../types.js";
+
+export function JsonField({
+  value,
+  collapsed = false,
+}: JsonFieldProps) {
+  const [isCollapsed, setIsCollapsed] = useState(collapsed);
+
+  if (value == null) {
+    return createElement("span", null, "—");
+  }
+
+  const formatted = JSON.stringify(value, null, 2);
+
+  if (isCollapsed) {
+    const preview = JSON.stringify(value);
+    const short = preview.length > 60 ? `${preview.slice(0, 60)}…` : preview;
+    return createElement(
+      "span",
+      null,
+      createElement("code", null, short),
+      " ",
+      createElement("button", {
+        onClick: () => setIsCollapsed(false),
+        style: { border: "none", background: "none", cursor: "pointer", color: "#666", fontSize: "12px" },
+      }, "expand"),
+    );
+  }
+
+  return createElement(
+    "pre",
+    {
+      style: {
+        margin: 0,
+        fontSize: "13px",
+        backgroundColor: "#f5f5f5",
+        padding: "8px",
+        borderRadius: "4px",
+        overflow: "auto",
+      },
+    },
+    createElement("code", null, formatted),
+  );
+}

--- a/packages/ui/src/fields/number-field.tsx
+++ b/packages/ui/src/fields/number-field.tsx
@@ -1,0 +1,26 @@
+import { createElement } from "react";
+import type { NumberFieldProps } from "../types.js";
+
+export function NumberField({
+  value,
+  locale = "en",
+  currency,
+  decimals,
+}: NumberFieldProps) {
+  if (value == null) {
+    return createElement("span", null, "—");
+  }
+
+  const options: Intl.NumberFormatOptions = {};
+  if (currency) {
+    options.style = "currency";
+    options.currency = currency;
+  }
+  if (decimals !== undefined) {
+    options.minimumFractionDigits = decimals;
+    options.maximumFractionDigits = decimals;
+  }
+
+  const formatted = new Intl.NumberFormat(locale, options).format(value);
+  return createElement("span", null, formatted);
+}

--- a/packages/ui/src/fields/relation-field.tsx
+++ b/packages/ui/src/fields/relation-field.tsx
@@ -1,0 +1,23 @@
+import { createElement } from "react";
+import type { RelationFieldProps } from "../types.js";
+
+export function RelationField({
+  value,
+  display = "name",
+  linkTo,
+}: RelationFieldProps) {
+  if (value == null) {
+    return createElement("span", null, "—");
+  }
+
+  const record = value as Record<string, unknown>;
+  const displayValue = String(record[display] ?? record.id ?? value);
+  const id = record.id as string | undefined;
+
+  if (linkTo && id) {
+    const href = linkTo.replace(":id", id);
+    return createElement("a", { href }, displayValue);
+  }
+
+  return createElement("span", null, displayValue);
+}

--- a/packages/ui/src/fields/text-field.tsx
+++ b/packages/ui/src/fields/text-field.tsx
@@ -1,0 +1,21 @@
+import { createElement } from "react";
+import type { TextFieldProps } from "../types.js";
+
+export function TextField({
+  value,
+  maxLength,
+}: TextFieldProps) {
+  if (value == null) {
+    return createElement("span", null, "—");
+  }
+
+  const display = maxLength && value.length > maxLength
+    ? `${value.slice(0, maxLength)}…`
+    : value;
+
+  if (maxLength && value.length > maxLength) {
+    return createElement("span", { title: value }, display);
+  }
+
+  return createElement("span", null, display);
+}

--- a/packages/ui/src/fields/url-field.tsx
+++ b/packages/ui/src/fields/url-field.tsx
@@ -1,0 +1,25 @@
+import { createElement } from "react";
+import type { UrlFieldProps } from "../types.js";
+
+export function UrlField({ value, truncate }: UrlFieldProps) {
+  if (value == null) {
+    return createElement("span", null, "—");
+  }
+
+  let display = value;
+  if (truncate) {
+    try {
+      const url = new URL(value);
+      display = url.hostname + (url.pathname !== "/" ? url.pathname : "");
+    } catch {
+      // Not a valid URL, show as-is
+    }
+  }
+
+  return createElement(
+    "a",
+    { href: value, target: "_blank", rel: "noopener noreferrer" },
+    display,
+    " ↗",
+  );
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -12,6 +12,13 @@ export { ActionButton } from "./components/action-button.js";
 export { ConfirmProvider } from "./components/confirm-provider.js";
 export { FormStatus } from "./components/form-status.js";
 export { AvatarWithInitials, getInitials } from "./components/avatar-with-initials.js";
+
+// Typed fields
+export {
+  DateField, BooleanField, NumberField, TextField,
+  EmailField, UrlField, ImageField, FileField,
+  RelationField, JsonField, fieldForColumn, fieldsForTable,
+} from "./fields/index.js";
 export { RoleBadge } from "./components/role-badge.js";
 export { ImpersonationBanner } from "./components/impersonation-banner.js";
 


### PR DESCRIPTION
## Summary
- 10 TypedField components: Date, Boolean, Number, Text, Email, Url, Image, File, Relation, Json
- `fieldForColumn()` maps Drizzle column metadata to field components
- `fieldsForTable()` maps an entire table
- All formatting via `Intl.*` APIs (Workers-compatible)

## Test plan
- [x] 24 new tests pass (72 total)

> Part 5 of 10. Depends on PR 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)