### PR TITLE
fix(storage,email): validate JSON.parse results instead of as casts

### DIFF
--- a/packages/email/src/mailgun.ts
+++ b/packages/email/src/mailgun.ts
@@ -66,8 +66,24 @@ export function mailgun(getConfig: () => MailgunConfig): EmailProvider {
         );
       }
 
-      const data = (await response.json()) as { id: string };
-      return { id: data.id };
+      // JSON parsing boundary: validate response shape before use
+      const data: unknown = await response.json();
+      if (
+        typeof data === "object" &&
+        data !== null &&
+        "id" in data &&
+        typeof data.id === "string"
+      ) {
+        return { id: data.id };
+      }
+      throw new EmailDeliveryError(
+        "Mailgun API returned an unexpected response shape",
+        {
+          provider: "mailgun",
+          statusCode: response.status,
+          response: JSON.stringify(data),
+        },
+      );
     },
   };
 }

--- a/packages/storage/src/client/use-upload.ts
+++ b/packages/storage/src/client/use-upload.ts
@@ -2,6 +2,48 @@ import { useState, useCallback } from "react";
 import { useStorageConfig } from "./storage-provider.js";
 import type { UploadResult } from "../types.js";
 
+/** Type guard: check that `value` is a non-null object with the given `keys`. */
+function hasKeys<K extends string>(
+  value: unknown,
+  keys: readonly K[],
+): value is Record<K, unknown> {
+  if (typeof value !== "object" || value === null) return false;
+  for (const k of keys) {
+    if (!(k in value)) return false;
+  }
+  return true;
+}
+
+/**
+ * Validate that a parsed JSON value matches the {@link UploadResult} shape.
+ *
+ * @returns The validated result, or `null` if the shape doesn't match.
+ */
+function parseUploadResult(value: unknown): UploadResult | null {
+  if (
+    hasKeys(value, ["key", "size", "type"]) &&
+    typeof value.key === "string" &&
+    typeof value.size === "number" &&
+    typeof value.type === "string"
+  ) {
+    return { key: value.key, size: value.size, type: value.type };
+  }
+  return null;
+}
+
+/**
+ * Extract a human-readable error string from a parsed JSON error body.
+ *
+ * Looks for `detail` or `message` string fields, returning `undefined` if
+ * neither is found.
+ */
+function parseErrorDetail(value: unknown): string | undefined {
+  if (typeof value !== "object" || value === null) return undefined;
+  if ("detail" in value && typeof value.detail === "string") return value.detail;
+  if ("message" in value && typeof value.message === "string") return value.message;
+  return undefined;
+}
+
 /** Return value of the {@link useUpload} hook. */
 export type UploadHookResult = {
   /** Comma-separated MIME types suitable for an `<input accept>` attribute. */
@@ -115,16 +157,21 @@ export function useUpload(name: string): UploadHookResult {
         setIsUploading(false);
         if (xhr.status >= 200 && xhr.status < 300) {
           try {
-            const data = JSON.parse(xhr.responseText) as UploadResult;
-            setResult(data);
-            setProgress(100);
+            const parsed: unknown = JSON.parse(xhr.responseText);
+            const data = parseUploadResult(parsed);
+            if (data) {
+              setResult(data);
+              setProgress(100);
+            } else {
+              setError("Invalid response from server");
+            }
           } catch {
             setError("Invalid response from server");
           }
         } else {
           try {
-            const data = JSON.parse(xhr.responseText) as { detail?: string; message?: string };
-            setError(data.detail ?? data.message ?? `Upload failed (${xhr.status})`);
+            const parsed: unknown = JSON.parse(xhr.responseText);
+            setError(parseErrorDetail(parsed) ?? `Upload failed (${xhr.status})`);
           } catch {
             setError(`Upload failed (${xhr.status})`);
           }

--- a/packages/storage/src/handle.ts
+++ b/packages/storage/src/handle.ts
@@ -53,7 +53,10 @@ export async function handleUpload<TInput>(
   }
 
   // 8. Get the bucket from env
-  const bucket = (ctx.env as Record<string, R2Bucket>)[config.bucket];
+  // Workers env boundary: R2 bucket bindings are injected by the Workers runtime
+  // and typed as `unknown` via HandleContext.env. We validate presence and cast
+  // to R2Bucket since there is no runtime type tag to check beyond existence.
+  const bucket = ctx.env[config.bucket] as R2Bucket | undefined;
   if (!bucket) {
     throw new Error(`R2 bucket binding "${config.bucket}" not found in env`);
   }


### PR DESCRIPTION
## Summary
- **`@cfast/storage` `use-upload.ts`**: Replace `as UploadResult` and `as { detail?: string; message?: string }` casts on `JSON.parse()` results with runtime shape validation using `hasKeys` type guard and dedicated `parseUploadResult`/`parseErrorDetail` helpers.
- **`@cfast/storage` `handle.ts`**: Replace `(ctx.env as Record<string, R2Bucket>)` double cast with a direct index + documented single cast at the Workers env boundary (`ctx.env[config.bucket] as R2Bucket | undefined`).
- **`@cfast/email` `mailgun.ts`**: Replace `(await response.json()) as { id: string }` with `unknown` + `in` narrowing, throwing `EmailDeliveryError` if the response shape is unexpected.

## Test plan
- [x] `pnpm --filter @cfast/storage typecheck` passes
- [x] `pnpm --filter @cfast/email typecheck` passes
- [x] `pnpm --filter @cfast/storage test` passes (59 tests)
- [x] `pnpm --filter @cfast/email test` passes (17 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)