### PR TITLE
fix(actions,pagination): replace `as` casts with runtime validation

### DIFF
--- a/packages/actions/src/client/use-actions.ts
+++ b/packages/actions/src/client/use-actions.ts
@@ -31,11 +31,53 @@ export type ActionHookResult = {
   error: unknown | undefined;
 };
 
+/**
+ * Narrows an `unknown` value to `Record<string, unknown>` if it is a non-null object.
+ * Returns an empty object otherwise so callers always get a safe record to index into.
+ */
+function asRecord(value: unknown): Record<string, unknown> {
+  if (value !== null && typeof value === "object" && !Array.isArray(value)) {
+    return value as Record<string, unknown>;
+  }
+  return {};
+}
+
+/**
+ * Validates that an `unknown` value has the shape of an {@link ActionPermissionStatus}.
+ */
+function isPermissionStatus(v: unknown): v is ActionPermissionStatus {
+  if (v === null || typeof v !== "object") return false;
+  const obj = v as Record<string, unknown>;
+  return (
+    typeof obj.permitted === "boolean" &&
+    typeof obj.invisible === "boolean" &&
+    (obj.reason === null || typeof obj.reason === "string")
+  );
+}
+
+/**
+ * Extracts an {@link ActionPermissionsMap} from raw loader data.
+ * Returns an empty map if the data does not contain valid permissions.
+ */
+function extractPermissions(loaderData: Record<string, unknown>): ActionPermissionsMap {
+  const raw = loaderData._actionPermissions;
+  if (raw === null || typeof raw !== "object" || Array.isArray(raw)) {
+    return {};
+  }
+  const map: ActionPermissionsMap = {};
+  for (const [key, value] of Object.entries(raw)) {
+    if (isPermissionStatus(value)) {
+      map[key] = value;
+    }
+  }
+  return map;
+}
+
 export function useActions(
   descriptor: ClientDescriptor,
 ): Record<string, (input?: Serializable) => ActionHookResult> {
-  const loaderData = useLoaderData() as Record<string, unknown>;
-  const permissions = (loaderData?._actionPermissions ?? {}) as ActionPermissionsMap;
+  const loaderData = asRecord(useLoaderData());
+  const permissions = extractPermissions(loaderData);
 
   // Pre-allocate one fetcher per action (hooks can't be in loops/conditions).
   // descriptor.actionNames is a static readonly array set at module init time,
@@ -59,9 +101,8 @@ export function useActions(
         const formData = new FormData();
         formData.set("_action", name);
         if (input && typeof input === "object" && !Array.isArray(input)) {
-          for (const [key, value] of Object.entries(
-            input as Record<string, Serializable>,
-          )) {
+          const entries = Object.entries(input);
+          for (const [key, value] of entries) {
             if (value !== null && value !== undefined) {
               formData.set(key, String(value));
             }

--- a/packages/pagination/src/use-offset-pagination.ts
+++ b/packages/pagination/src/use-offset-pagination.ts
@@ -27,6 +27,30 @@ export type UseOffsetPaginationResult<T> = {
 };
 
 /**
+ * Validates that a value conforms to the {@link OffsetPageData} shape.
+ * Returns a valid `OffsetPageData` or a fallback with sensible defaults.
+ */
+function asOffsetPageData(value: unknown): OffsetPageData {
+  if (value !== null && typeof value === "object" && !Array.isArray(value)) {
+    const obj = value as Record<string, unknown>;
+    if (
+      Array.isArray(obj.items) &&
+      typeof obj.total === "number" &&
+      typeof obj.page === "number" &&
+      typeof obj.totalPages === "number"
+    ) {
+      return {
+        items: obj.items,
+        total: obj.total,
+        page: obj.page,
+        totalPages: obj.totalPages,
+      };
+    }
+  }
+  return { items: [], total: 0, page: 1, totalPages: 0 };
+}
+
+/**
  * React hook for offset-based (page number) pagination with React Router loader data.
  *
  * Reads the current page data from React Router's `useLoaderData()` and provides
@@ -51,7 +75,7 @@ export type UseOffsetPaginationResult<T> = {
  * ```
  */
 export function useOffsetPagination<T = unknown>(): UseOffsetPaginationResult<T> {
-  const data = useLoaderData() as OffsetPageData;
+  const data = asOffsetPageData(useLoaderData());
   const navigate = useNavigate();
   const location = useLocation();
 
@@ -65,6 +89,8 @@ export function useOffsetPagination<T = unknown>(): UseOffsetPaginationResult<T>
   );
 
   return {
+    // Items come from loader data as unknown[]; the generic T is a trust boundary
+    // where the caller asserts their loader returns the correct item shape.
     items: data.items as T[],
     total: data.total,
     totalPages: data.totalPages,

--- a/packages/pagination/src/use-pagination.ts
+++ b/packages/pagination/src/use-pagination.ts
@@ -32,8 +32,37 @@ export type UsePaginationResult<T> = {
   isLoading: boolean;
 };
 
+/**
+ * Validates that a value conforms to the {@link CursorPageData} shape.
+ * Returns a valid `CursorPageData` or a fallback with empty items.
+ */
+function asCursorPageData(value: unknown): CursorPageData {
+  if (value !== null && typeof value === "object" && !Array.isArray(value)) {
+    const obj = value as Record<string, unknown>;
+    if (Array.isArray(obj.items)) {
+      return {
+        items: obj.items,
+        nextCursor:
+          typeof obj.nextCursor === "string" ? obj.nextCursor : null,
+      };
+    }
+  }
+  return { items: [], nextCursor: null };
+}
+
+/**
+ * Default key extractor that reads the `id` property from an item.
+ * Uses an `in` check to safely narrow the type before accessing `id`.
+ */
 function defaultGetKey(item: unknown): string | number {
-  return (item as Record<string, unknown>).id as string | number;
+  if (item !== null && typeof item === "object" && "id" in item) {
+    // After the `in` check, TS narrows to `Record<"id", unknown>`
+    const { id } = item;
+    if (typeof id === "string" || typeof id === "number") {
+      return id;
+    }
+  }
+  return "";
 }
 
 function deduplicateItems<T>(
@@ -79,12 +108,13 @@ function deduplicateItems<T>(
 export function usePagination<T = unknown>(
   options?: UsePaginationOptions<T>,
 ): UsePaginationResult<T> {
-  const loaderData = useLoaderData() as CursorPageData;
+  const loaderData = asCursorPageData(useLoaderData());
   const fetcher = useFetcher<CursorPageData>();
   const location = useLocation();
-  const getKey = (options?.getKey ?? defaultGetKey) as (
-    item: T,
-  ) => string | number;
+  // defaultGetKey operates on `unknown` which is safe for any T,
+  // so the fallback assignment is type-compatible.
+  const getKey: (item: T) => string | number =
+    options?.getKey ?? (defaultGetKey as (item: T) => string | number);
 
   const [pages, setPages] = useState<CursorPageData[]>(() => [loaderData]);
 
@@ -105,7 +135,11 @@ export function usePagination<T = unknown>(
   }, [fetcher.data, fetcher.state]);
 
   const allItems = useMemo(
-    () => deduplicateItems(pages.flatMap((p) => p.items) as T[], getKey),
+    () =>
+      deduplicateItems(
+        pages.flatMap((p) => p.items) as T[],
+        getKey,
+      ),
     [pages, getKey],
   );
 


### PR DESCRIPTION
## Summary
- Add runtime validation helpers (`asRecord`, `extractPermissions`, `asCursorPageData`, `asOffsetPageData`) to validate `useLoaderData()` results before typing them, eliminating bare `as` casts in `@cfast/actions` and `@cfast/pagination`
- Replace `defaultGetKey`'s unsafe cast with proper `in` operator narrowing to safely access `item.id`
- Remove the `as Record<string, Serializable>` cast in `useActions` input handling by using `Object.entries` directly on the narrowed object

## Test plan
- [x] `pnpm --filter @cfast/actions typecheck` passes
- [x] `pnpm --filter @cfast/pagination typecheck` passes
- [x] `pnpm --filter @cfast/actions test` passes (55 tests)
- [x] `pnpm --filter @cfast/pagination test` passes (12 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)