### PR TITLE
fix(core): eliminate plugin composition double cast

### DIFF
--- a/packages/core/src/client/provider.tsx
+++ b/packages/core/src/client/provider.tsx
@@ -1,5 +1,5 @@
 import { createContext, type ReactNode, type ComponentType } from "react";
-import type { CfastPlugin } from "../types";
+import type { RuntimePlugin } from "../types";
 
 /** React context holding client-side plugin values for `useApp()`. */
 export const CoreContext = createContext<Record<string, unknown> | null>(null);
@@ -16,7 +16,7 @@ type ProviderComponent = ComponentType<{ children: ReactNode }>;
  * @returns A React component that wraps children with all plugin providers and the core context.
  */
 export function createCoreProvider(
-  plugins: Pick<CfastPlugin, "name" | "Provider" | "client">[],
+  plugins: Pick<RuntimePlugin, "name" | "Provider" | "client">[],
 ): ProviderComponent {
   // Build client context value from plugins that have client exports
   const clientValue: Record<string, unknown> = {};
@@ -38,7 +38,10 @@ export function createCoreProvider(
     // Nest providers: first registered = outermost
     let tree = children;
     for (let i = providers.length - 1; i >= 0; i--) {
-      const P = providers[i] as ProviderComponent;
+      // providers[i] is guaranteed defined because we iterate within bounds.
+      // The non-null assertion avoids an unnecessary cast; the array element
+      // type is already ProviderComponent.
+      const P = providers[i]!;
       tree = <P>{tree}</P>;
     }
 

--- a/packages/core/src/client/use-app.ts
+++ b/packages/core/src/client/use-app.ts
@@ -28,5 +28,10 @@ export function useApp<T = Record<string, unknown>>(): T {
         "Wrap your app with the Provider from createApp().",
     );
   }
+  // Type boundary: CoreContext stores Record<string, unknown> because React's
+  // createContext cannot carry the full generic plugin type from createApp().
+  // The caller narrows T to their app's actual client context type, which is
+  // guaranteed to match at runtime because createCoreProvider populates the
+  // context value from the registered plugins' client exports.
   return ctx as T;
 }

--- a/packages/core/src/create-app.ts
+++ b/packages/core/src/create-app.ts
@@ -3,10 +3,12 @@ import type { Schema, ParsedEnv } from "@cfast/env";
 import type { Permissions } from "@cfast/permissions";
 import type {
   CfastPlugin,
+  RuntimePlugin,
   CreateAppConfig,
   AppContext,
   RouteArgs,
   App,
+  PluginSetupContext,
 } from "./types";
 import { CfastPluginError, CfastConfigError } from "./errors";
 import { createCoreProvider } from "./client/provider";
@@ -52,7 +54,7 @@ function buildApp<
 >(
   envInstance: { init(raw: Record<string, unknown>): void; get(): ParsedEnv<TSchema> },
   permissions: TPermissions,
-  plugins: CfastPlugin[],
+  plugins: RuntimePlugin[],
 ): App<TSchema, TPermissions, TPluginContext, TClientContext> {
   const pluginNames = new Set(plugins.map((p) => p.name));
 
@@ -81,7 +83,15 @@ function buildApp<
           ...accumulated,
         };
         try {
-          const result = await plugin.setup(setupCtx);
+          // Type boundary: RuntimePlugin.setup is typed as (ctx: never) => unknown
+          // so that all CfastPlugin subtypes can be stored without casting. At
+          // runtime, setupCtx contains { request, env, ...priorPluginResults },
+          // which satisfies each plugin's TRequires. The type system cannot verify
+          // this statically because the accumulated shape depends on registration
+          // order, so we cast the context to the setup parameter type here.
+          const result = await plugin.setup(
+            setupCtx as PluginSetupContext<never>,
+          );
           accumulated[plugin.name] = result;
         } catch (e) {
           if (e instanceof CfastPluginError) throw e;
@@ -89,6 +99,11 @@ function buildApp<
         }
       }
 
+      // Type boundary: we dynamically build the context by accumulating each
+      // plugin's setup result keyed by plugin name. The resulting object matches
+      // AppContext<TSchema, TPluginContext> at runtime, but TypeScript cannot
+      // track the incremental type growth through the for-loop, so we assert
+      // the final shape here.
       return { env, ...accumulated } as AppContext<TSchema, TPluginContext>;
     },
 
@@ -130,12 +145,16 @@ function buildApp<
         );
       }
 
+      // No cast needed: CfastPlugin<TName, TProvides, TPluginContext, TClient>
+      // is structurally assignable to RuntimePlugin because RuntimePlugin.setup
+      // uses PluginSetupContext<never> in the contravariant parameter position,
+      // and never extends any TRequires.
       return buildApp<
         TSchema,
         TPermissions,
         TPluginContext & { [K in TName]: TProvides },
         TClientContext & (TClient extends object ? { [K in TName]: TClient } : unknown)
-      >(envInstance, permissions, [...plugins, plugin as unknown as CfastPlugin]);
+      >(envInstance, permissions, [...plugins, plugin]);
     },
 
     Provider: createCoreProvider(plugins),

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -63,6 +63,36 @@ export type CfastPlugin<
 };
 
 /**
+ * Minimal plugin shape used internally for runtime iteration in `buildApp`.
+ *
+ * The `setup` parameter uses `PluginSetupContext<never>` so that every concrete
+ * `CfastPlugin<TName, TProvides, TRequires, TClient>` is structurally assignable
+ * to this type without casting — `never` extends any `TRequires`, satisfying
+ * function parameter contravariance.
+ *
+ * At the call site in `context()`, we use a single documented cast to invoke
+ * `setup` with the actual runtime context, since TypeScript cannot prove that
+ * accumulated plugin results satisfy each plugin's `TRequires`.
+ *
+ * This type is internal and not part of the public API.
+ */
+export type RuntimePlugin = {
+  /** Plugin name used as the namespace key. */
+  name: string;
+  /**
+   * Setup function called per-request.
+   *
+   * Typed with `never` parameter to make all `CfastPlugin` subtypes assignable.
+   * Called at runtime via a documented cast in `context()`.
+   */
+  setup: (ctx: PluginSetupContext<never>) => unknown | Promise<unknown>;
+  /** Optional client-side React provider. */
+  Provider?: ComponentType<{ children: ReactNode }>;
+  /** Optional client-side values. */
+  client?: unknown;
+};
+
+/**
  * Utility type that extracts `{ [name]: ReturnType<setup> }` from a plugin definition.
  *
  * Use this to create a type token that dependent plugins can reference via `definePlugin<TRequires>()`.


### PR DESCRIPTION
## Summary
- Introduced an internal `RuntimePlugin` type using `PluginSetupContext<never>` in the contravariant `setup` parameter position, making all `CfastPlugin` subtypes structurally assignable without casting
- Removed the `plugin as unknown as CfastPlugin` double cast in `use()` — now a zero-cast assignment
- Replaced `as ProviderComponent` cast in `provider.tsx` with a non-null assertion on the bounded array index
- Documented remaining inherent type boundary casts (`as PluginSetupContext<never>` at the `setup` call site, `as AppContext` for the accumulated context, `as T` in `useApp()`) with explanatory comments

## Test plan
- [x] `pnpm --filter @cfast/core typecheck` passes
- [x] `pnpm --filter @cfast/core test` passes (23/23 tests)
- [x] No new `any` types introduced
- [x] No double casts remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)