### PR TITLE
refactor(forms): replace double casts with typed Drizzle boundary helpers

### DIFF
--- a/packages/forms/src/drizzle-internals.ts
+++ b/packages/forms/src/drizzle-internals.ts
@@ -1,0 +1,147 @@
+/**
+ * Typed boundary types for accessing Drizzle ORM internal properties.
+ *
+ * Drizzle's `Column` and `ColumnBuilder` classes expose some metadata as public
+ * properties (`dataType`, `columnType`, `notNull`, etc.) but mark the `config`
+ * object as `protected`. We need to read `config` in two places:
+ *
+ * 1. To read `config.length` on text columns (set by `text("col", { length: N })`),
+ *    so we can derive `maxLength` validation rules.
+ * 2. To read/write `config[VALIDATE_SYMBOL]` for storing custom validation rules
+ *    via the `v()` helper.
+ *
+ * These types document the internal structure we depend on and provide a single
+ * place to update if Drizzle's internals change. They replace scattered
+ * `as unknown as X` double-casts with a named, documented boundary.
+ *
+ * @internal
+ * @module
+ */
+
+/**
+ * Describes the protected `config` object on a Drizzle `Column` instance.
+ *
+ * Drizzle stores runtime column metadata in `config` (typed as
+ * `ColumnBuilderRuntimeConfig<TData, TRuntimeConfig>` internally). The
+ * properties we access are:
+ *
+ * - `length` (optional): Set by `text("col", { length: N })` on SQLite text columns.
+ * - `[symbol]` entries: Used by `v()` for custom validation rules via VALIDATE_SYMBOL.
+ *
+ * @internal
+ */
+type DrizzleColumnConfig = {
+  readonly length?: number;
+  [key: symbol]: unknown;
+};
+
+/**
+ * Minimal shape of the protected `config` on a `ColumnBuilder`, used by `v()`
+ * to write validation rules before the column is built.
+ *
+ * @internal
+ */
+type DrizzleBuilderConfig = {
+  [key: symbol]: unknown;
+};
+
+/**
+ * The internal properties of a Drizzle `Column` that we access for form
+ * introspection. Combines public properties (which Drizzle exposes but
+ * TypeScript's `Column` type parameterises away) with the protected `config`.
+ *
+ * Used in `introspectTable` to read column metadata without repeated inline casts.
+ *
+ * @internal
+ */
+export type DrizzleColumnMeta = {
+  readonly dataType: string;
+  readonly columnType: string;
+  readonly notNull: boolean;
+  readonly hasDefault: boolean;
+  readonly primary: boolean;
+  readonly enumValues?: readonly string[] | string[];
+  readonly config: DrizzleColumnConfig;
+};
+
+/**
+ * The internal shape of a Drizzle `ColumnBuilder`, providing access to the
+ * protected `config` property. Used by `v()` to attach validation rules.
+ *
+ * @internal
+ */
+export type ColumnBuilderInternal = {
+  config: DrizzleBuilderConfig;
+};
+
+/**
+ * The internal shape of a built Drizzle `Column` for reading validation rules.
+ * Used by `getValidationRules()` to retrieve rules attached via `v()`.
+ *
+ * @internal
+ */
+export type ColumnInternal = {
+  readonly config: DrizzleColumnConfig;
+};
+
+/**
+ * Cast a Drizzle `Column` (from `getTableColumns`) to our typed boundary type.
+ *
+ * Drizzle's public `Column` type hides concrete property types behind generics.
+ * At runtime the properties exist; this function provides typed access while
+ * keeping the cast in one auditable location.
+ *
+ * Why this is needed: `getTableColumns()` returns `Record<string, Column>`, where
+ * `Column` is generic. The concrete properties (`dataType`, `notNull`, `config`,
+ * etc.) are present at runtime but not directly accessible through the generic
+ * type. Additionally, `config` is `protected` and cannot be accessed without
+ * crossing the type boundary.
+ *
+ * @param column - A Drizzle column instance from `getTableColumns`.
+ * @returns The same object typed as {@link DrizzleColumnMeta}.
+ *
+ * @internal
+ */
+export function asDrizzleColumnMeta(column: unknown): DrizzleColumnMeta {
+  // Single cast at the documented Drizzle internal access boundary.
+  // The runtime shape is guaranteed by Drizzle's Column class implementation.
+  return column as DrizzleColumnMeta;
+}
+
+/**
+ * Cast a Drizzle `ColumnBuilder` to our typed boundary type for writing config.
+ *
+ * Drizzle marks `config` as `protected`, so external code cannot write to it
+ * without a cast. This function provides typed access at a single boundary point.
+ *
+ * Why this is needed: The `v()` helper stores validation rules on the builder's
+ * `config` object using a Symbol key. This survives into the built Column instance
+ * because Drizzle passes `config` through during construction.
+ *
+ * @param builder - A Drizzle column builder instance.
+ * @returns The same object typed as {@link ColumnBuilderInternal}.
+ *
+ * @internal
+ */
+export function asBuilderInternal(builder: unknown): ColumnBuilderInternal {
+  // Single cast at the documented Drizzle internal access boundary.
+  // The runtime shape is guaranteed by Drizzle's ColumnBuilder class implementation.
+  return builder as ColumnBuilderInternal;
+}
+
+/**
+ * Cast a built Drizzle `Column` to our typed boundary type for reading config.
+ *
+ * Why this is needed: The `getValidationRules()` function reads validation rules
+ * from the Column's protected `config` object that were previously written by `v()`.
+ *
+ * @param column - A built Drizzle Column instance.
+ * @returns The same object typed as {@link ColumnInternal}.
+ *
+ * @internal
+ */
+export function asColumnInternal(column: unknown): ColumnInternal {
+  // Single cast at the documented Drizzle internal access boundary.
+  // The runtime shape is guaranteed by Drizzle's Column class implementation.
+  return column as ColumnInternal;
+}

--- a/packages/forms/src/introspect.ts
+++ b/packages/forms/src/introspect.ts
@@ -1,5 +1,6 @@
 import { getTableColumns } from "drizzle-orm";
 import type { SQLiteTable } from "drizzle-orm/sqlite-core";
+import { asDrizzleColumnMeta } from "./drizzle-internals";
 import type { FieldDefinition, InputType, ValidationRules } from "./types";
 import { getValidationRules } from "./validate";
 
@@ -57,15 +58,9 @@ export function introspectTable(table: SQLiteTable): FieldDefinition[] {
 
   for (const [key, column] of Object.entries(columns)) {
     const customRules = getValidationRules(column) ?? {};
-    const col = column as unknown as {
-      dataType: string;
-      columnType: string;
-      notNull: boolean;
-      hasDefault: boolean;
-      primary: boolean;
-      enumValues?: readonly string[] | string[];
-      config: { length?: number };
-    };
+    // Access Drizzle column internals via the typed boundary helper.
+    // See drizzle-internals.ts for documentation on why this is needed.
+    const col = asDrizzleColumnMeta(column);
 
     const validation: ValidationRules = { ...customRules };
 

--- a/packages/forms/src/resolver.ts
+++ b/packages/forms/src/resolver.ts
@@ -108,15 +108,21 @@ export function createResolver(
     }
 
     if (hasErrors) {
+      // On validation failure, react-hook-form expects an empty `values` object
+      // (typed as Record<string, never> in ResolverError).
+      const emptyValues: Record<string, never> = {};
       return {
-        values: {} as Record<string, never>,
+        values: emptyValues,
         errors,
       };
     }
 
+    // On success, react-hook-form expects an empty `errors` object
+    // (typed as Record<string, never> in ResolverSuccess).
+    const noErrors: Record<string, never> = {};
     return {
       values,
-      errors: {} as Record<string, never>,
+      errors: noErrors,
     };
   };
 }

--- a/packages/forms/src/validate.ts
+++ b/packages/forms/src/validate.ts
@@ -1,5 +1,6 @@
 import type { Column } from "drizzle-orm";
 import type { ColumnBuilderBase } from "drizzle-orm/column-builder";
+import { asBuilderInternal, asColumnInternal } from "./drizzle-internals";
 import type { ValidationRules } from "./types";
 
 /**
@@ -38,9 +39,9 @@ export function v<T extends ColumnBuilderBase>(
   builder: T,
   rules: ValidationRules,
 ): T {
-  (
-    (builder as unknown as { config: Record<symbol, unknown> }).config
-  )[VALIDATE_SYMBOL] = rules;
+  // Access the protected config via the typed boundary helper.
+  // See drizzle-internals.ts for documentation on why this is needed.
+  asBuilderInternal(builder).config[VALIDATE_SYMBOL] = rules;
   return builder;
 }
 
@@ -55,7 +56,11 @@ export function v<T extends ColumnBuilderBase>(
 export function getValidationRules(
   column: Column,
 ): ValidationRules | undefined {
-  return (column as unknown as { config: Record<symbol, unknown> }).config[
-    VALIDATE_SYMBOL
-  ] as ValidationRules | undefined;
+  // Access the protected config via the typed boundary helper.
+  // See drizzle-internals.ts for documentation on why this is needed.
+  const value = asColumnInternal(column).config[VALIDATE_SYMBOL];
+  if (value === undefined) {
+    return undefined;
+  }
+  return value as ValidationRules;
 }


### PR DESCRIPTION
## Summary
- Introduce `DrizzleColumnMeta`, `ColumnBuilderInternal`, and `ColumnInternal` boundary types in a new `drizzle-internals.ts` module, documenting the internal Drizzle ORM properties accessed for form introspection and validation rule storage
- Replace all `as unknown as X` double-casts in `introspect.ts` and `validate.ts` with named boundary functions (`asDrizzleColumnMeta`, `asBuilderInternal`, `asColumnInternal`) that centralize Drizzle internal access in one auditable location
- Replace `{} as Record<string, never>` inline casts in `resolver.ts` with properly typed local variables

## Test plan
- [x] `pnpm --filter @cfast/forms typecheck` passes
- [x] `pnpm --filter @cfast/forms test` passes (34/34 tests across 6 test files)
- [x] No `as unknown as` double-casts remain in source files
- [x] No `any` types introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)