### PR TITLE
fix(db): remove `any` casts from utils, query-builder, and mutate-builder

### DIFF
--- a/packages/db/src/mutate-builder.ts
+++ b/packages/db/src/mutate-builder.ts
@@ -1,4 +1,6 @@
 import { drizzle } from "drizzle-orm/d1";
+import type { SQL } from "drizzle-orm";
+import type { SQLiteTable } from "drizzle-orm/sqlite-core";
 import type { Grant, PermissionDescriptor, DrizzleTable } from "@cfast/permissions";
 import { checkOperationPermissions } from "./permissions";
 import { buildPermissionFilter, combineWhere, makePermissions, getTableName } from "./utils";
@@ -58,14 +60,14 @@ function buildMutationWithReturning(
  * @returns An insert builder with a `values()` method.
  */
 export function createInsertBuilder(config: MutateBuilderConfig) {
-  const db = drizzle(config.d1, { schema: config.schema as Record<string, any> });
+  const db = drizzle(config.d1, { schema: config.schema });
   const permissions = makePermissions(config.unsafe, "create", config.table);
   const tableName = getTableName(config.table);
 
   return {
     values(values: Record<string, unknown>) {
       return buildMutationWithReturning(config, permissions, tableName, async (returning) => {
-        const query = db.insert(config.table as any).values(values);
+        const query = db.insert(config.table as SQLiteTable).values(values);
         if (returning) {
           return query.returning().get();
         }
@@ -85,7 +87,7 @@ export function createInsertBuilder(config: MutateBuilderConfig) {
  * @returns An update builder with a `set()` method that chains to `where()`.
  */
 export function createUpdateBuilder(config: MutateBuilderConfig) {
-  const db = drizzle(config.d1, { schema: config.schema as Record<string, any> });
+  const db = drizzle(config.d1, { schema: config.schema });
   const permissions = makePermissions(config.unsafe, "update", config.table);
   const tableName = getTableName(config.table);
 
@@ -96,10 +98,11 @@ export function createUpdateBuilder(config: MutateBuilderConfig) {
           const permFilter = buildPermissionFilter(
             config.grants, "update", config.table, config.user, config.unsafe,
           );
-          const combinedWhere = combineWhere(condition, permFilter);
+          const combinedWhere = combineWhere(condition as SQL | undefined, permFilter);
 
           return buildMutationWithReturning(config, permissions, tableName, async (returning) => {
-            const query = db.update(config.table as any).set(values).where(combinedWhere as any);
+            const query = db.update(config.table as SQLiteTable).set(values);
+            if (combinedWhere) query.where(combinedWhere);
             if (returning) {
               return query.returning().get();
             }
@@ -121,7 +124,7 @@ export function createUpdateBuilder(config: MutateBuilderConfig) {
  * @returns A delete builder with a `where()` method.
  */
 export function createDeleteBuilder(config: MutateBuilderConfig) {
-  const db = drizzle(config.d1, { schema: config.schema as Record<string, any> });
+  const db = drizzle(config.d1, { schema: config.schema });
   const permissions = makePermissions(config.unsafe, "delete", config.table);
   const tableName = getTableName(config.table);
 
@@ -130,10 +133,11 @@ export function createDeleteBuilder(config: MutateBuilderConfig) {
       const permFilter = buildPermissionFilter(
         config.grants, "delete", config.table, config.user, config.unsafe,
       );
-      const combinedWhere = combineWhere(condition, permFilter);
+      const combinedWhere = combineWhere(condition as SQL | undefined, permFilter);
 
       return buildMutationWithReturning(config, permissions, tableName, async (returning) => {
-        const query = db.delete(config.table as any).where(combinedWhere as any);
+        const query = db.delete(config.table as SQLiteTable);
+        if (combinedWhere) query.where(combinedWhere);
         if (returning) {
           return query.returning().get();
         }

--- a/packages/db/src/query-builder.ts
+++ b/packages/db/src/query-builder.ts
@@ -19,11 +19,38 @@ type QueryBuilderConfig = {
   unsafe: boolean;
 };
 
+/**
+ * Minimal shape of a Drizzle relational query builder.
+ * Matches the `findMany` and `findFirst` methods we use from `db.query[tableName]`.
+ */
+type DrizzleRelationalQueryBuilder = {
+  findMany(config?: Record<string, unknown>): Promise<unknown[]>;
+  findFirst(config?: Record<string, unknown>): Promise<unknown>;
+};
+
+/**
+ * The `db.query` record after schema registration. Drizzle types this as a mapped type
+ * over the schema generic, but since we pass `Record<string, unknown>` we access via
+ * a typed record at this single boundary point.
+ */
+type DrizzleQueryMap = Record<string, DrizzleRelationalQueryBuilder>;
+
 function getTableKey(schema: Record<string, unknown>, table: DrizzleTable): string | undefined {
   for (const [key, val] of Object.entries(schema)) {
     if (val === table) return key;
   }
   return undefined;
+}
+
+/**
+ * Returns the relational query builder for a table key from a Drizzle db instance.
+ * Centralizes the single cast needed to access `db.query[key]` with a dynamic key.
+ */
+function getQueryTable(
+  db: ReturnType<typeof drizzle>,
+  key: string,
+): DrizzleRelationalQueryBuilder {
+  return (db.query as DrizzleQueryMap)[key];
 }
 
 function buildQueryOperation<TResult>(
@@ -45,7 +72,7 @@ function buildQueryOperation<TResult>(
       const permFilter = buildPermissionFilter(
         config.grants, "read", config.table, config.user, config.unsafe,
       );
-      const userWhere = options?.where;
+      const userWhere = options?.where as SQL | undefined;
       const combinedWhere = combineWhere(userWhere, permFilter);
 
       const queryOptions: Record<string, unknown> = { ...options };
@@ -54,7 +81,8 @@ function buildQueryOperation<TResult>(
       }
       delete queryOptions.cache;
 
-      const result = await (db.query as any)[tableKey][method](queryOptions);
+      const queryTable = getQueryTable(db, tableKey);
+      const result = await queryTable[method](queryOptions);
       return (method === "findFirst" ? result ?? undefined : result) as TResult;
     },
   };
@@ -70,7 +98,7 @@ function buildQueryOperation<TResult>(
  * @returns A query builder with `findMany`, `findFirst`, and `paginate` methods.
  */
 export function createQueryBuilder(config: QueryBuilderConfig) {
-  const db = drizzle(config.d1, { schema: config.schema as Record<string, any> });
+  const db = drizzle(config.d1, { schema: config.schema });
   const tableKey = getTableKey(config.schema, config.table);
 
   return {
@@ -105,17 +133,20 @@ export function createQueryBuilder(config: QueryBuilderConfig) {
         return tableKey;
       }
 
-      function checkAndBuildWhere(extraWhere?: unknown) {
+      function checkAndBuildWhere(extraWhere?: SQL | undefined) {
         if (!config.unsafe) {
           checkOperationPermissions(config.grants, permissions);
         }
         const permFilter = buildPermissionFilter(
           config.grants, "read", config.table, config.user, config.unsafe,
         );
-        return combineWhere(combineWhere(options?.where, permFilter), extraWhere);
+        return combineWhere(
+          combineWhere(options?.where as SQL | undefined, permFilter),
+          extraWhere,
+        );
       }
 
-      function buildBaseQueryOptions(where: unknown) {
+      function buildBaseQueryOptions(where: SQL | undefined) {
         const qo: Record<string, unknown> = {};
         if (options?.columns) qo.columns = options.columns;
         if (options?.orderBy) qo.orderBy = options.orderBy;
@@ -140,17 +171,15 @@ export function createQueryBuilder(config: QueryBuilderConfig) {
             const queryOptions = buildBaseQueryOptions(combinedWhere);
             queryOptions.limit = params.limit + 1;
 
-            const rows = await (db.query as any)[key].findMany(queryOptions) as unknown[];
+            const queryTable = getQueryTable(db, key);
+            const rows = await queryTable.findMany(queryOptions) as unknown[];
             const hasMore = rows.length > params.limit;
             const items = hasMore ? rows.slice(0, params.limit) : rows;
 
             let nextCursor: string | null = null;
             if (hasMore && items.length > 0) {
               const lastItem = items[items.length - 1] as Record<string, unknown>;
-              const values = cursorColumns.map((col) => {
-                const colName = (col as any).name as string;
-                return lastItem[colName];
-              });
+              const values = cursorColumns.map((col) => lastItem[col.name]);
               nextCursor = encodeCursor(values);
             }
 
@@ -173,10 +202,11 @@ export function createQueryBuilder(config: QueryBuilderConfig) {
             .select({ count: count() })
             .from(config.table as SQLiteTable)
             .$dynamic();
-          if (combinedWhere) countQuery.where(combinedWhere as SQL);
+          if (combinedWhere) countQuery.where(combinedWhere);
 
+          const queryTable = getQueryTable(db, key);
           const [items, countResult] = await Promise.all([
-            (db.query as any)[key].findMany(queryOptions) as Promise<unknown[]>,
+            queryTable.findMany(queryOptions) as Promise<unknown[]>,
             countQuery,
           ]);
 

--- a/packages/db/src/utils.ts
+++ b/packages/db/src/utils.ts
@@ -1,4 +1,5 @@
 import { and, or } from "drizzle-orm";
+import type { SQL, SQLWrapper } from "drizzle-orm";
 import type { DrizzleTable, Grant, PermissionAction, PermissionDescriptor } from "@cfast/permissions";
 import { getTableName } from "@cfast/permissions";
 import { resolvePermissionFilters } from "./permissions";
@@ -28,18 +29,27 @@ export function buildPermissionFilter(
   table: DrizzleTable,
   user: User | null,
   unsafe: boolean,
-): unknown {
+): SQL | undefined {
   if (unsafe || !user) return undefined;
   const filters = resolvePermissionFilters(grants, action, table);
   if (filters.length === 0) return undefined;
   const columns = table as Record<string, unknown>;
-  const clauses = filters.map((fn) => fn(columns, user));
-  return clauses.length === 1 ? clauses[0] : or(...(clauses as [any, ...any[]]));
+  // Permission filter fns return DrizzleSQL (structurally { getSQL(): unknown }),
+  // which at runtime are Drizzle SQL expressions compatible with SQLWrapper.
+  const clauses = filters.map(
+    (fn) => fn(columns, user) as SQLWrapper | undefined,
+  );
+  return or(...clauses);
 }
 
-export function combineWhere(userCondition: unknown, permFilter: unknown): unknown {
-  if (permFilter && userCondition) return and(userCondition as any, permFilter as any);
-  return (permFilter ?? userCondition) as any;
+export function combineWhere(
+  userCondition: SQL | SQLWrapper | undefined,
+  permFilter: SQL | SQLWrapper | undefined,
+): SQL | undefined {
+  if (permFilter && userCondition) return and(userCondition, permFilter);
+  if (permFilter) return permFilter.getSQL();
+  if (userCondition) return userCondition.getSQL();
+  return undefined;
 }
 
 export function makePermissions(


### PR DESCRIPTION
## Summary
- **utils.ts**: Type `buildPermissionFilter` return as `SQL | undefined` and `combineWhere` params as `SQL | SQLWrapper | undefined`, eliminating all `as any` casts
- **query-builder.ts**: Create centralized `getQueryTable()` helper to replace scattered `(db.query as any)[key]` patterns; use `Column.name` directly instead of `(col as any).name`; remove `combineWhere as any` and `schema as Record<string, any>` casts
- **mutate-builder.ts**: Replace `config.table as any` with `config.table as SQLiteTable`; remove `combineWhere as any` and `schema as Record<string, any>` casts

## Test plan
- [x] `pnpm --filter @cfast/db typecheck` passes cleanly
- [x] `pnpm --filter @cfast/db test` passes all 97 tests
- [x] No `as any` casts remain in source files (only in test mocks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)