### PR TITLE
fix(admin): narrow overly broad types

### DIFF
--- a/packages/admin/package.json
+++ b/packages/admin/package.json
@@ -33,6 +33,7 @@
   "dependencies": {
     "@cfast/db": "workspace:*",
     "@cfast/forms": "workspace:*",
+    "@cfast/permissions": "workspace:*",
     "@cfast/ui": "workspace:*"
   },
   "devDependencies": {

--- a/packages/admin/src/loader.ts
+++ b/packages/admin/src/loader.ts
@@ -1,4 +1,5 @@
 import { getTableColumns, getTableName, eq, like, or, asc, desc } from "drizzle-orm";
+import type { SQL } from "drizzle-orm";
 import type { SQLiteTable } from "drizzle-orm/sqlite-core";
 import type { Db } from "@cfast/db";
 import { parseAdminParams } from "./utils.js";
@@ -12,6 +13,54 @@ import type {
 } from "./types.js";
 
 const PAGE_SIZE = 20;
+
+/**
+ * Validates that a value is an array of plain objects (records).
+ *
+ * Used to safely narrow `unknown[]` query results from the DB layer into
+ * `Record<string, unknown>[]` without `as` casts.
+ *
+ * @param value - The unknown value to validate.
+ * @returns The value typed as `Record<string, unknown>[]`.
+ * @throws {TypeError} If the value is not an array of plain objects.
+ */
+function asRecords(value: unknown): Record<string, unknown>[] {
+  if (!Array.isArray(value)) {
+    throw new TypeError(
+      `Expected an array of records, got ${typeof value}`,
+    );
+  }
+  for (let i = 0; i < value.length; i++) {
+    if (typeof value[i] !== "object" || value[i] === null || Array.isArray(value[i])) {
+      throw new TypeError(
+        `Expected record at index ${i}, got ${Array.isArray(value[i]) ? "array" : typeof value[i]}`,
+      );
+    }
+  }
+  return value as Record<string, unknown>[];
+}
+
+/**
+ * Validates that a value is a single plain object (record) or `undefined`.
+ *
+ * Used to safely narrow `unknown | undefined` query results from the DB layer
+ * into `Record<string, unknown> | undefined` without `as` casts.
+ *
+ * @param value - The unknown value to validate.
+ * @returns The value typed as `Record<string, unknown> | undefined`.
+ * @throws {TypeError} If the value is defined but not a plain object.
+ */
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+  if (typeof value !== "object" || Array.isArray(value)) {
+    throw new TypeError(
+      `Expected a record, got ${Array.isArray(value) ? "array" : typeof value}`,
+    );
+  }
+  return value as Record<string, unknown>;
+}
 
 /**
  * Shared table list for the sidebar, derived from tableMetas.
@@ -62,7 +111,7 @@ function buildSearchWhere(
   drizzleTable: SQLiteTable,
   searchableColumns: string[],
   search: string,
-): unknown {
+): SQL | undefined {
   if (!search || searchableColumns.length === 0) {
     return undefined;
   }
@@ -88,7 +137,7 @@ function buildOrderBy(
   drizzleTable: SQLiteTable,
   sortColumn: string,
   direction: "asc" | "desc",
-): unknown {
+): SQL | undefined {
   const col = getColumn(drizzleTable, sortColumn);
   if (!col) return undefined;
   return direction === "asc" ? asc(col) : desc(col);
@@ -121,7 +170,7 @@ async function loadDashboard(
         stats.push({ label: widget.label, value: rows.length });
       } else if (widget.type === "recent") {
         const limit = widget.limit ?? 5;
-        const items = (await db
+        const items = asRecords(await db
           .query(meta.drizzleTable)
           .findMany({
             limit,
@@ -131,7 +180,7 @@ async function loadDashboard(
               "desc",
             ),
           })
-          .run({})) as Record<string, unknown>[];
+          .run({}));
         recentItems.push({
           table: meta.name,
           label: widget.label,
@@ -152,7 +201,7 @@ async function loadDashboard(
 
     const firstMeta = tableMetas[0];
     if (firstMeta) {
-      const items = (await db
+      const items = asRecords(await db
         .query(firstMeta.drizzleTable)
         .findMany({
           limit: 5,
@@ -162,7 +211,7 @@ async function loadDashboard(
             "desc",
           ),
         })
-        .run({})) as Record<string, unknown>[];
+        .run({}));
       recentItems.push({
         table: firstMeta.name,
         label: firstMeta.label,
@@ -225,7 +274,7 @@ async function loadList(
 
   // Fetch page of items
   const offset = (page - 1) * PAGE_SIZE;
-  const items = (await db
+  const items = asRecords(await db
     .query(meta.drizzleTable)
     .findMany({
       where,
@@ -233,7 +282,7 @@ async function loadList(
       limit: PAGE_SIZE,
       offset,
     })
-    .run({})) as Record<string, unknown>[];
+    .run({}));
 
   const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
 
@@ -286,10 +335,10 @@ async function loadDetail(
     };
   }
 
-  const item = (await db
+  const item = asRecord(await db
     .query(meta.drizzleTable)
     .findFirst({ where: eq(pkCol, id) })
-    .run({})) as Record<string, unknown> | undefined;
+    .run({}));
 
   if (!item) {
     return {
@@ -373,10 +422,10 @@ async function loadEdit(
     };
   }
 
-  const item = (await db
+  const item = asRecord(await db
     .query(meta.drizzleTable)
     .findFirst({ where: eq(pkCol, id) })
-    .run({})) as Record<string, unknown> | undefined;
+    .run({}));
 
   if (!item) {
     return {
@@ -437,14 +486,14 @@ async function loadUserList(
 
   // Fetch page of users
   const offset = (page - 1) * PAGE_SIZE;
-  const rawUsers = (await unsafeDb
+  const rawUsers = asRecords(await unsafeDb
     .query(usersTable)
     .findMany({
       where,
       limit: PAGE_SIZE,
       offset,
     })
-    .run({})) as Record<string, unknown>[];
+    .run({}));
 
   // Enrich with roles
   const items: Array<AdminUser & { createdAt?: string }> = [];
@@ -510,10 +559,10 @@ async function loadUserDetail(
     };
   }
 
-  const raw = (await unsafeDb
+  const raw = asRecord(await unsafeDb
     .query(usersTable)
     .findFirst({ where: eq(pkCol, targetId) })
-    .run({})) as Record<string, unknown> | undefined;
+    .run({}));
 
   if (!raw) {
     return {

--- a/packages/admin/src/types.ts
+++ b/packages/admin/src/types.ts
@@ -1,6 +1,7 @@
 import type { SQLiteTable } from "drizzle-orm/sqlite-core";
 import type { Db } from "@cfast/db";
 import type { FieldConfig } from "@cfast/forms";
+import type { Grant } from "@cfast/permissions";
 
 /**
  * A user representation for the admin panel, decoupled from `@cfast/auth`.
@@ -67,7 +68,7 @@ export type AdminAuthConfig = {
   /** Extracts the authenticated user and their permission grants from the request. Throws or redirects if unauthenticated. */
   requireUser: (
     request: Request,
-  ) => Promise<{ user: AdminUser; grants: unknown[] }>;
+  ) => Promise<{ user: AdminUser; grants: Grant[] }>;
   /** Checks whether the given user has a specific role. Used for the admin access guard. */
   hasRole: (user: AdminUser, role: string) => boolean;
   /** Fetches all roles assigned to a user by ID. Used in user management views. */
@@ -105,7 +106,7 @@ export type AdminAuthConfig = {
  * ```
  */
 export type CreateDbFn = (
-  grants: unknown[],
+  grants: Grant[],
   user: { id: string } | null,
 ) => Db;
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -84,64 +84,6 @@ importers:
     devDependencies:
       '@cloudflare/vite-plugin':
         specifier: ^1.27.0
-        version: 1.28.0(vite@8.0.0(@types/node@24.12.0)(esbuild@0.27.3)(tsx@4.21.0)(yaml@2.8.2))(workerd@1.20260312.1)(wrangler@4.73.0(@cloudflare/workers-types@4.20260313.1))
-      '@cloudflare/workers-types':
-        specifier: ^4.20260310.1
-        version: 4.20260313.1
-      '@react-router/dev':
-        specifier: ^7.13.1
-        version: 7.13.1(@types/node@24.12.0)(babel-plugin-macros@3.1.0)(lightningcss@1.32.0)(react-router@7.13.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.0(@types/node@24.12.0)(esbuild@0.27.3)(tsx@4.21.0)(yaml@2.8.2))(wrangler@4.73.0(@cloudflare/workers-types@4.20260313.1))(yaml@2.8.2)
-      '@types/react':
-        specifier: ^19.2.7
-        version: 19.2.14
-      '@types/react-dom':
-        specifier: ^19.2.3
-        version: 19.2.3(@types/react@19.2.14)
-      drizzle-kit:
-        specifier: ^0.31.9
-        version: 0.31.9
-      typescript:
-        specifier: ^5.9.2
-        version: 5.9.3
-      vite:
-        specifier: ^8.0.0
-        version: 8.0.0(@types/node@24.12.0)(esbuild@0.27.3)(tsx@4.21.0)(yaml@2.8.2)
-      wrangler:
-        specifier: ^4.72.0
-        version: 4.73.0(@cloudflare/workers-types@4.20260313.1)
-
-  docs/tutorials/team-blog/step-03-auth:
-    dependencies:
-      '@cfast/auth':
-        specifier: workspace:*
-        version: link:../../../../packages/auth
-      '@cfast/db':
-        specifier: workspace:*
-        version: link:../../../../packages/db
-      '@cfast/env':
-        specifier: workspace:*
-        version: link:../../../../packages/env
-      '@cfast/permissions':
-        specifier: workspace:*
-        version: link:../../../../packages/permissions
-      better-auth:
-        specifier: ^1.2.0
-        version: 1.5.3(@better-auth/drizzle-adapter@1.5.3(@better-auth/core@1.5.3(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260313.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.0)(kysely@0.28.11)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(drizzle-orm@0.45.1(@cloudflare/workers-types@4.20260313.1)(kysely@0.28.11)))(@cloudflare/workers-types@4.20260313.1)(drizzle-kit@0.31.9)(drizzle-orm@0.45.1(@cloudflare/workers-types@4.20260313.1)(kysely@0.28.11))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.1.0(@types/node@24.12.0)(jsdom@28.1.0(@noble/hashes@2.0.1))(vite@8.0.0(@types/node@24.12.0)(esbuild@0.25.12)(tsx@4.21.0)(yaml@2.8.2)))
-      drizzle-orm:
-        specifier: ^0.45.1
-        version: 0.45.1(@cloudflare/workers-types@4.20260313.1)(kysely@0.28.11)
-      react:
-        specifier: ^19.2.4
-        version: 19.2.4
-      react-dom:
-        specifier: ^19.2.4
-        version: 19.2.4(react@19.2.4)
-      react-router:
-        specifier: ^7.13.1
-        version: 7.13.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-    devDependencies:
-      '@cloudflare/vite-plugin':
-        specifier: ^1.27.0
         version: 1.28.0(vite@8.0.0(@types/node@24.12.0)(esbuild@0.25.12)(tsx@4.21.0)(yaml@2.8.2))(workerd@1.20260312.1)(wrangler@4.73.0(@cloudflare/workers-types@4.20260313.1))
       '@cloudflare/workers-types':
         specifier: ^4.20260310.1
@@ -164,6 +106,64 @@ importers:
       vite:
         specifier: ^8.0.0
         version: 8.0.0(@types/node@24.12.0)(esbuild@0.25.12)(tsx@4.21.0)(yaml@2.8.2)
+      wrangler:
+        specifier: ^4.72.0
+        version: 4.73.0(@cloudflare/workers-types@4.20260313.1)
+
+  docs/tutorials/team-blog/step-03-auth:
+    dependencies:
+      '@cfast/auth':
+        specifier: workspace:*
+        version: link:../../../../packages/auth
+      '@cfast/db':
+        specifier: workspace:*
+        version: link:../../../../packages/db
+      '@cfast/env':
+        specifier: workspace:*
+        version: link:../../../../packages/env
+      '@cfast/permissions':
+        specifier: workspace:*
+        version: link:../../../../packages/permissions
+      better-auth:
+        specifier: ^1.2.0
+        version: 1.5.3(@better-auth/drizzle-adapter@1.5.3(@better-auth/core@1.5.3(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260313.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.0)(kysely@0.28.11)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(drizzle-orm@0.45.1(@cloudflare/workers-types@4.20260313.1)(kysely@0.28.11)))(@cloudflare/workers-types@4.20260313.1)(drizzle-kit@0.31.9)(drizzle-orm@0.45.1(@cloudflare/workers-types@4.20260313.1)(kysely@0.28.11))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.1.0(@types/node@24.12.0)(jsdom@28.1.0(@noble/hashes@2.0.1))(vite@8.0.0(@types/node@24.12.0)(esbuild@0.27.3)(tsx@4.21.0)(yaml@2.8.2)))
+      drizzle-orm:
+        specifier: ^0.45.1
+        version: 0.45.1(@cloudflare/workers-types@4.20260313.1)(kysely@0.28.11)
+      react:
+        specifier: ^19.2.4
+        version: 19.2.4
+      react-dom:
+        specifier: ^19.2.4
+        version: 19.2.4(react@19.2.4)
+      react-router:
+        specifier: ^7.13.1
+        version: 7.13.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+    devDependencies:
+      '@cloudflare/vite-plugin':
+        specifier: ^1.27.0
+        version: 1.28.0(vite@8.0.0(@types/node@24.12.0)(esbuild@0.27.3)(tsx@4.21.0)(yaml@2.8.2))(workerd@1.20260312.1)(wrangler@4.73.0(@cloudflare/workers-types@4.20260313.1))
+      '@cloudflare/workers-types':
+        specifier: ^4.20260310.1
+        version: 4.20260313.1
+      '@react-router/dev':
+        specifier: ^7.13.1
+        version: 7.13.1(@types/node@24.12.0)(babel-plugin-macros@3.1.0)(lightningcss@1.32.0)(react-router@7.13.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.0(@types/node@24.12.0)(esbuild@0.27.3)(tsx@4.21.0)(yaml@2.8.2))(wrangler@4.73.0(@cloudflare/workers-types@4.20260313.1))(yaml@2.8.2)
+      '@types/react':
+        specifier: ^19.2.7
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.14)
+      drizzle-kit:
+        specifier: ^0.31.9
+        version: 0.31.9
+      typescript:
+        specifier: ^5.9.2
+        version: 5.9.3
+      vite:
+        specifier: ^8.0.0
+        version: 8.0.0(@types/node@24.12.0)(esbuild@0.27.3)(tsx@4.21.0)(yaml@2.8.2)
       wrangler:
         specifier: ^4.72.0
         version: 4.73.0(@cloudflare/workers-types@4.20260313.1)
@@ -845,6 +845,9 @@ importers:
       '@cfast/forms':
         specifier: workspace:*
         version: link:../forms
+      '@cfast/permissions':
+        specifier: workspace:*
+        version: link:../permissions
       '@cfast/ui':
         specifier: workspace:*
         version: link:../ui
@@ -9219,32 +9222,6 @@ snapshots:
     transitivePeerDependencies:
       - '@cloudflare/workers-types'
 
-  better-auth@1.5.3(@better-auth/drizzle-adapter@1.5.3(@better-auth/core@1.5.3(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260313.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.0)(kysely@0.28.11)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(drizzle-orm@0.45.1(@cloudflare/workers-types@4.20260313.1)(kysely@0.28.11)))(@cloudflare/workers-types@4.20260313.1)(drizzle-kit@0.31.9)(drizzle-orm@0.45.1(@cloudflare/workers-types@4.20260313.1)(kysely@0.28.11))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.1.0(@types/node@24.12.0)(jsdom@28.1.0(@noble/hashes@2.0.1))(vite@8.0.0(@types/node@24.12.0)(esbuild@0.25.12)(tsx@4.21.0)(yaml@2.8.2))):
-    dependencies:
-      '@better-auth/core': 1.5.3(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260313.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.0)(kysely@0.28.11)(nanostores@1.1.1)
-      '@better-auth/kysely-adapter': 1.5.3(@better-auth/core@1.5.3(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260313.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.0)(kysely@0.28.11)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(kysely@0.28.11)
-      '@better-auth/memory-adapter': 1.5.3(@better-auth/core@1.5.3(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260313.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.0)(kysely@0.28.11)(nanostores@1.1.1))(@better-auth/utils@0.3.1)
-      '@better-auth/telemetry': 1.5.3(@better-auth/core@1.5.3(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260313.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.0)(kysely@0.28.11)(nanostores@1.1.1))
-      '@better-auth/utils': 0.3.1
-      '@better-fetch/fetch': 1.1.21
-      '@noble/ciphers': 2.1.1
-      '@noble/hashes': 2.0.1
-      better-call: 1.3.2(zod@4.3.6)
-      defu: 6.1.4
-      jose: 6.2.0
-      kysely: 0.28.11
-      nanostores: 1.1.1
-      zod: 4.3.6
-    optionalDependencies:
-      '@better-auth/drizzle-adapter': 1.5.3(@better-auth/core@1.5.3(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260313.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.0)(kysely@0.28.11)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(drizzle-orm@0.45.1(@cloudflare/workers-types@4.20260313.1)(kysely@0.28.11))
-      drizzle-kit: 0.31.9
-      drizzle-orm: 0.45.1(@cloudflare/workers-types@4.20260313.1)(kysely@0.28.11)
-      react: 19.2.4
-      react-dom: 19.2.4(react@19.2.4)
-      vitest: 4.1.0(@types/node@24.12.0)(jsdom@28.1.0(@noble/hashes@2.0.1))(vite@8.0.0(@types/node@24.12.0)(esbuild@0.25.12)(tsx@4.21.0)(yaml@2.8.2))
-    transitivePeerDependencies:
-      - '@cloudflare/workers-types'
-
   better-auth@1.5.3(@better-auth/drizzle-adapter@1.5.3(@better-auth/core@1.5.3(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260313.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.0)(kysely@0.28.11)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(drizzle-orm@0.45.1(@cloudflare/workers-types@4.20260313.1)(kysely@0.28.11)))(@cloudflare/workers-types@4.20260313.1)(drizzle-kit@0.31.9)(drizzle-orm@0.45.1(@cloudflare/workers-types@4.20260313.1)(kysely@0.28.11))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.1.0(@types/node@24.12.0)(jsdom@28.1.0(@noble/hashes@2.0.1))(vite@8.0.0(@types/node@24.12.0)(esbuild@0.27.3)(tsx@4.21.0)(yaml@2.8.2))):
     dependencies:
       '@better-auth/core': 1.5.3(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260313.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.0)(kysely@0.28.11)(nanostores@1.1.1)
@@ -12360,35 +12337,6 @@ snapshots:
       jsdom: 26.1.0
     transitivePeerDependencies:
       - msw
-
-  vitest@4.1.0(@types/node@24.12.0)(jsdom@28.1.0(@noble/hashes@2.0.1))(vite@8.0.0(@types/node@24.12.0)(esbuild@0.25.12)(tsx@4.21.0)(yaml@2.8.2)):
-    dependencies:
-      '@vitest/expect': 4.1.0
-      '@vitest/mocker': 4.1.0(vite@8.0.0(@types/node@24.12.0)(esbuild@0.25.12)(tsx@4.21.0)(yaml@2.8.2))
-      '@vitest/pretty-format': 4.1.0
-      '@vitest/runner': 4.1.0
-      '@vitest/snapshot': 4.1.0
-      '@vitest/spy': 4.1.0
-      '@vitest/utils': 4.1.0
-      es-module-lexer: 2.0.0
-      expect-type: 1.3.0
-      magic-string: 0.30.21
-      obug: 2.1.1
-      pathe: 2.0.3
-      picomatch: 4.0.3
-      std-env: 4.0.0
-      tinybench: 2.9.0
-      tinyexec: 1.0.2
-      tinyglobby: 0.2.15
-      tinyrainbow: 3.0.3
-      vite: 8.0.0(@types/node@24.12.0)(esbuild@0.25.12)(tsx@4.21.0)(yaml@2.8.2)
-      why-is-node-running: 2.3.0
-    optionalDependencies:
-      '@types/node': 24.12.0
-      jsdom: 28.1.0(@noble/hashes@2.0.1)
-    transitivePeerDependencies:
-      - msw
-    optional: true
 
   vitest@4.1.0(@types/node@24.12.0)(jsdom@28.1.0(@noble/hashes@2.0.1))(vite@8.0.0(@types/node@24.12.0)(esbuild@0.27.3)(tsx@4.21.0)(yaml@2.8.2)):
     dependencies:


### PR DESCRIPTION
## Summary
- Replace `grants: unknown[]` with `grants: Grant[]` (from `@cfast/permissions`) in `AdminAuthConfig.requireUser` and `CreateDbFn` types
- Type `buildSearchWhere` and `buildOrderBy` returns as `SQL | undefined` (from `drizzle-orm`) instead of `unknown`
- Add `asRecords()` and `asRecord()` runtime validation helpers that replace 7 unsafe `as` casts on DB query results with proper type narrowing
- Add `@cfast/permissions` as a dependency of `@cfast/admin`

## Test plan
- [x] `pnpm --filter @cfast/admin typecheck` passes
- [x] `pnpm --filter @cfast/admin test` passes (146 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)