### PR TITLE
fix(permissions): eliminate `any` from foundation types

### DIFF
--- a/packages/permissions/src/__tests__/check.test.ts
+++ b/packages/permissions/src/__tests__/check.test.ts
@@ -3,10 +3,12 @@ import { checkPermissions } from "../check";
 import { definePermissions } from "../define-permissions";
 import { grant } from "../grant";
 
+import type { DrizzleTable } from "../types";
+
 const DRIZZLE_NAME = Symbol.for("drizzle:Name");
-const posts = { [DRIZZLE_NAME]: "posts" } as any;
-const comments = { [DRIZZLE_NAME]: "comments" } as any;
-const auditLogs = { [DRIZZLE_NAME]: "audit_logs" } as any;
+const posts: DrizzleTable = { [DRIZZLE_NAME]: "posts" };
+const comments: DrizzleTable = { [DRIZZLE_NAME]: "comments" };
+const auditLogs: DrizzleTable = { [DRIZZLE_NAME]: "audit_logs" };
 
 const permissions = definePermissions({
   roles: ["anonymous", "user", "editor", "admin"] as const,

--- a/packages/permissions/src/__tests__/define-permissions.test.ts
+++ b/packages/permissions/src/__tests__/define-permissions.test.ts
@@ -1,9 +1,10 @@
 import { describe, it, expect } from "vitest";
 import { definePermissions } from "../define-permissions";
 import { grant } from "../grant";
+import type { DrizzleTable } from "../types";
 
-const posts = { _: { name: "posts" } } as any;
-const _comments = { _: { name: "comments" } } as any;
+const posts: DrizzleTable = { _: { name: "posts" } };
+const _comments: DrizzleTable = { _: { name: "comments" } };
 
 describe("definePermissions", () => {
   describe("basic (no hierarchy)", () => {

--- a/packages/permissions/src/__tests__/errors.test.ts
+++ b/packages/permissions/src/__tests__/errors.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect } from "vitest";
 import { ForbiddenError } from "../errors";
+import type { DrizzleTable } from "../types";
 
-const posts = { [Symbol.for("drizzle:Name")]: "posts" } as any;
+const posts: DrizzleTable = { [Symbol.for("drizzle:Name")]: "posts" };
 
 describe("ForbiddenError", () => {
   it("is an instance of Error", () => {

--- a/packages/permissions/src/__tests__/grant.test.ts
+++ b/packages/permissions/src/__tests__/grant.test.ts
@@ -1,8 +1,9 @@
 import { describe, it, expect } from "vitest";
 import { grant } from "../grant";
+import type { DrizzleTable, WhereClause } from "../types";
 
-const posts = { _: { name: "posts" } } as any;
-const _comments = { _: { name: "comments" } } as any;
+const posts: DrizzleTable = { _: { name: "posts" } };
+const _comments: DrizzleTable = { _: { name: "comments" } };
 
 describe("grant", () => {
   it("creates a grant with action and subject", () => {
@@ -13,7 +14,7 @@ describe("grant", () => {
   });
 
   it("creates a grant with a where clause", () => {
-    const whereFn = (row: any) => row.published;
+    const whereFn: WhereClause = (_columns, _user) => ({ getSQL: () => ({ }) });
     const g = grant("read", posts, { where: whereFn });
     expect(g.action).toBe("read");
     expect(g.subject).toBe(posts);

--- a/packages/permissions/src/__tests__/resolve-grants.test.ts
+++ b/packages/permissions/src/__tests__/resolve-grants.test.ts
@@ -2,10 +2,10 @@ import { describe, it, expect, vi } from "vitest";
 import { definePermissions } from "../define-permissions";
 import { grant } from "../grant";
 import { resolveGrants } from "../resolve-grants";
-import type { DrizzleSQL } from "../types";
+import type { DrizzleSQL, DrizzleTable, WhereClause } from "../types";
 
-const posts = { _: { name: "posts" } } as any;
-const comments = { _: { name: "comments" } } as any;
+const posts: DrizzleTable = { _: { name: "posts" } };
+const comments: DrizzleTable = { _: { name: "comments" } };
 
 const fakeSql = (tag: string): DrizzleSQL => ({ getSQL: () => tag });
 
@@ -86,8 +86,8 @@ describe("resolveGrants", () => {
   });
 
   it("OR-merges where clauses when all grants are restricted", () => {
-    const where1 = vi.fn((_cols: any, _user: any) => fakeSql("w1"));
-    const where2 = vi.fn((_cols: any, _user: any) => fakeSql("w2"));
+    const where1: WhereClause = vi.fn((_cols: Record<string, unknown>, _user: unknown) => fakeSql("w1"));
+    const where2: WhereClause = vi.fn((_cols: Record<string, unknown>, _user: unknown) => fakeSql("w2"));
 
     const p = definePermissions({
       roles: ["a", "b"] as const,
@@ -173,7 +173,7 @@ describe("resolveGrants", () => {
 
   it("groups by subject reference equality for tables", () => {
     // Two different table objects with the same name should NOT be merged
-    const posts2 = { _: { name: "posts" } } as any;
+    const posts2: DrizzleTable = { _: { name: "posts" } };
 
     const p = definePermissions({
       roles: ["a", "b"] as const,

--- a/packages/permissions/src/define-permissions.ts
+++ b/packages/permissions/src/define-permissions.ts
@@ -6,9 +6,10 @@ function buildPermissions<TRoles extends readonly string[]>(
 ): Permissions<TRoles> {
   const { roles, hierarchy } = config;
 
+  const grantFn: GrantFn<unknown> = grant;
   const grants =
     typeof config.grants === "function"
-      ? config.grants(grant as GrantFn<unknown>)
+      ? config.grants(grantFn)
       : config.grants;
 
   const resolvedGrants = resolveHierarchy(roles, grants, hierarchy);
@@ -61,11 +62,17 @@ export function definePermissions<TUser>(): <
 >(
   config: PermissionsConfig<TRoles, TUser>,
 ) => Permissions<TRoles>;
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function definePermissions(config?: any): any {
+export function definePermissions<TRoles extends readonly string[]>(
+  config?: PermissionsConfig<TRoles>,
+):
+  | Permissions<TRoles>
+  | (<TRoles2 extends readonly string[]>(
+      config: PermissionsConfig<TRoles2>,
+    ) => Permissions<TRoles2>) {
   if (config === undefined) {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    return (c: any) => buildPermissions(c);
+    return <TRoles2 extends readonly string[]>(
+      c: PermissionsConfig<TRoles2>,
+    ) => buildPermissions(c);
   }
   return buildPermissions(config);
 }
@@ -105,7 +112,7 @@ function resolveHierarchy<TRoles extends readonly string[]>(
   }
 
   for (const role of roles) {
-    resolve(role as string);
+    resolve(role);
   }
 
   return resolved;

--- a/packages/permissions/src/resolve-grants.ts
+++ b/packages/permissions/src/resolve-grants.ts
@@ -1,5 +1,23 @@
 import { or, type SQLWrapper } from "drizzle-orm";
-import type { Grant, Permissions } from "./types";
+import type { DrizzleSQL, Grant, Permissions } from "./types";
+
+/**
+ * Wraps a `DrizzleSQL` value for use with Drizzle's `or()`.
+ *
+ * At runtime, `DrizzleSQL` values from `where` callbacks are real Drizzle SQL
+ * objects that satisfy `SQLWrapper`. Our `DrizzleSQL` type uses
+ * `{ getSQL(): unknown }` intentionally to keep the permissions package loosely
+ * coupled from Drizzle internals. This adapter bridges the two at the
+ * drizzle-orm boundary.
+ *
+ * @param value - A `DrizzleSQL` value or `undefined`.
+ * @returns The same value typed as `SQLWrapper`, or `undefined`.
+ */
+function toSQLWrapper(value: DrizzleSQL | undefined): SQLWrapper | undefined {
+  // DrizzleSQL values are always real Drizzle SQL objects at runtime (SQLWrapper).
+  // This is the drizzle-orm type boundary — analogous to the Workers env boundary.
+  return value as SQLWrapper | undefined;
+}
 
 /**
  * Resolves and merges grants for multiple roles into a single flat array.
@@ -82,7 +100,7 @@ export function resolveGrants(
         // OR-merge all where clauses
         const merged: Grant["where"] = (columns, user) =>
           or(
-            ...(whereFns.map((fn) => fn(columns, user)) as (SQLWrapper | undefined)[]),
+            ...whereFns.map((fn) => toSQLWrapper(fn(columns, user))),
           );
 
         result.push({

--- a/packages/permissions/src/types.ts
+++ b/packages/permissions/src/types.ts
@@ -2,10 +2,11 @@
  * Minimal structural type for a Drizzle ORM table reference.
  *
  * Drizzle stores table metadata via Symbols (e.g., `Symbol('drizzle:Name')`).
- * This loose type avoids importing `drizzle-orm` directly into the permissions package.
+ * Uses `object` so real Drizzle table classes (which lack an explicit index
+ * signature) are assignable without an `as` cast, while still excluding
+ * primitives.
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type DrizzleTable = Record<string | symbol, any>;
+export type DrizzleTable = object;
 
 /**
  * Minimal structural type for a Drizzle SQL expression.
@@ -24,7 +25,12 @@ const DRIZZLE_NAME_SYMBOL = Symbol.for("drizzle:Name");
  * @returns The table name, or `"unknown"` if the symbol is not present.
  */
 export function getTableName(table: DrizzleTable): string {
-  return (table[DRIZZLE_NAME_SYMBOL] as string) ?? "unknown";
+  // Use DRIZZLE_NAME_SYMBOL as a property key on the table object.
+  // DrizzleTable is typed as `object` to accept Drizzle class instances;
+  // Reflect.get safely reads the symbol-keyed property without requiring
+  // an index signature.
+  const name: unknown = Reflect.get(table, DRIZZLE_NAME_SYMBOL);
+  return typeof name === "string" ? name : "unknown";
 }
 
 /**
@@ -69,8 +75,7 @@ export const CRUD_ACTIONS: readonly CrudAction[] = ["read", "create", "update", 
  */
 export type WhereClause = (
   columns: Record<string, unknown>,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  user: any,
+  user: unknown,
 ) => DrizzleSQL | undefined;
 
 /**


### PR DESCRIPTION
## Summary
- Replace all `any` types and `as` casts in `@cfast/permissions` source and test files
- Change `DrizzleTable` from `Record<string | symbol, any>` to `object` so real Drizzle table classes are assignable without casts
- Replace `user: any` in `WhereClause` with `user: unknown`
- Type the `definePermissions` implementation overload with proper generics instead of `any`
- Extract `toSQLWrapper()` boundary adapter in `resolve-grants.ts` to replace inline `as` cast for drizzle-orm interop
- Replace all `as any` mock tables in tests with `DrizzleTable`-typed fixtures

## Test plan
- [x] `pnpm --filter @cfast/permissions typecheck` passes
- [x] `pnpm --filter @cfast/permissions test` passes (61/61 tests)
- [x] `pnpm --filter @cfast/db typecheck` passes (downstream consumer)
- [x] `pnpm --filter @cfast/db test` passes (97/97 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)