### PR TITLE
fix(ui): remove type casts from components

### DIFF
--- a/packages/ui/src/components/data-table.tsx
+++ b/packages/ui/src/components/data-table.tsx
@@ -1,6 +1,7 @@
 import { useState, useCallback } from "react";
 import { useComponent } from "../plugin.js";
 import type { DataTableProps, ColumnDef, ColumnShorthand } from "../types.js";
+import { getField, getRecordId } from "../record-access.js";
 
 function normalizeColumns<T>(columns: ColumnShorthand<T>[] | undefined): ColumnDef<T>[] {
   if (!columns) return [];
@@ -135,7 +136,7 @@ export function DataTable<T = unknown>({
                 </TableCell>
               ) : null}
               {columns.map((col) => {
-                const value = (row as Record<string, unknown>)[col.key];
+                const value = getField(row, col.key);
                 return (
                   <TableCell key={col.key}>
                     {col.render ? col.render(value, row) : String(value ?? "")}
@@ -151,5 +152,5 @@ export function DataTable<T = unknown>({
 }
 
 function defaultGetId<T>(row: T): string | number {
-  return (row as Record<string, unknown>).id as string | number;
+  return getRecordId(row);
 }

--- a/packages/ui/src/components/detail-view.tsx
+++ b/packages/ui/src/components/detail-view.tsx
@@ -1,6 +1,7 @@
 import { PageContainer } from "./page-container.js";
 import { fieldForColumn } from "../fields/field-for-column.js";
 import type { DetailViewProps, ColumnDef, ColumnShorthand } from "../types.js";
+import { getField } from "../record-access.js";
 
 function normalizeFields<T>(
   fields: ColumnShorthand<T>[] | undefined,
@@ -74,7 +75,7 @@ export function DetailView<T = unknown>({
         }}
       >
         {displayFields.map((field) => {
-          const value = (record as Record<string, unknown>)[field.key];
+          const value = getField(record, field.key);
           const FieldComponent = field.render
             ? null
             : resolveFieldComponent(field.key, table);
@@ -112,7 +113,7 @@ function inferFieldsFromRecord<T>(
 ): ColumnDef<T>[] {
   if (!record || typeof record !== "object") return [];
 
-  return Object.keys(record as Record<string, unknown>)
+  return Object.keys(record)
     .filter((key) => !exclude || !exclude.includes(key))
     .map((key) => ({
       key,
@@ -129,11 +130,17 @@ function resolveFieldComponent(
 ): ReturnType<typeof fieldForColumn> | null {
   if (!table || typeof table !== "object") return null;
 
-  const col = (table as Record<string, unknown>)[_key];
-  if (!col || typeof col !== "object" || !("dataType" in col) || !("name" in col)) {
+  const col = getField(table, _key);
+  if (
+    !col ||
+    typeof col !== "object" ||
+    !("dataType" in col) ||
+    typeof col.dataType !== "string" ||
+    !("name" in col) ||
+    typeof col.name !== "string"
+  ) {
     return null;
   }
 
-  const meta = col as { dataType: string; name: string };
-  return fieldForColumn(meta);
+  return fieldForColumn({ dataType: col.dataType, name: col.name });
 }

--- a/packages/ui/src/fields/boolean-field.tsx
+++ b/packages/ui/src/fields/boolean-field.tsx
@@ -30,13 +30,25 @@ export function BooleanField({
     return <span>—</span>;
   }
 
+  const boolValue = Boolean(value);
+  const color = boolValue ? trueColor : falseColor;
+  const chipColor = isChipColor(color) ? color : "neutral";
+
   return (
     <Chip
-      color={(value ? trueColor : falseColor) as "success" | "neutral" | "danger" | "primary" | "warning"}
+      color={chipColor}
       variant="soft"
       size="sm"
     >
-      {value ? trueLabel : falseLabel}
+      {boolValue ? trueLabel : falseLabel}
     </Chip>
   );
+}
+
+const CHIP_COLORS = new Set<string>(["success", "neutral", "danger", "primary", "warning"]);
+
+function isChipColor(
+  value: string,
+): value is "success" | "neutral" | "danger" | "primary" | "warning" {
+  return CHIP_COLORS.has(value);
 }

--- a/packages/ui/src/fields/date-field.tsx
+++ b/packages/ui/src/fields/date-field.tsx
@@ -70,7 +70,11 @@ export function DateField({
     return <span>—</span>;
   }
 
-  const date = value instanceof Date ? value : new Date(value);
+  const date = value instanceof Date
+    ? value
+    : typeof value === "string" || typeof value === "number"
+      ? new Date(value)
+      : new Date(String(value));
 
   if (Number.isNaN(date.getTime())) {
     return <span>Invalid date</span>;

--- a/packages/ui/src/fields/email-field.tsx
+++ b/packages/ui/src/fields/email-field.tsx
@@ -19,5 +19,6 @@ export function EmailField({ value }: EmailFieldProps) {
     return <span>—</span>;
   }
 
-  return <a href={`mailto:${value}`}>{value}</a>;
+  const email = String(value);
+  return <a href={`mailto:${email}`}>{email}</a>;
 }

--- a/packages/ui/src/fields/field-for-column.ts
+++ b/packages/ui/src/fields/field-for-column.ts
@@ -1,5 +1,4 @@
-import type { ComponentType } from "react";
-import type { BaseFieldProps } from "../types.js";
+import type { FieldComponent } from "../types.js";
 import { DateField } from "./date-field.js";
 import { BooleanField } from "./boolean-field.js";
 import { NumberField } from "./number-field.js";
@@ -36,8 +35,7 @@ type ColumnMeta = {
  * // Field === DateField
  * ```
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function fieldForColumn(column: ColumnMeta): ComponentType<any> {
+export function fieldForColumn(column: ColumnMeta): FieldComponent {
   const { dataType, name } = column;
   const dt = dataType.toLowerCase();
 
@@ -98,16 +96,27 @@ export function fieldForColumn(column: ColumnMeta): ComponentType<any> {
  */
 export function fieldsForTable(
   table: { [Symbol.iterator]?: never } & Record<string, unknown>,
-): Record<string, ComponentType<BaseFieldProps & { value: unknown }>> {
+): Record<string, FieldComponent> {
   // Use drizzle-orm's getTableColumns if available
   // For now, we do a duck-type check for the column structure
-  const result: Record<string, ComponentType<BaseFieldProps & { value: unknown }>> = {};
+  const result: Record<string, FieldComponent> = {};
 
   for (const [key, col] of Object.entries(table)) {
-    if (col && typeof col === "object" && "dataType" in col && "name" in col) {
-      result[key] = fieldForColumn(col as ColumnMeta);
+    if (isColumnMeta(col)) {
+      result[key] = fieldForColumn(col);
     }
   }
 
   return result;
+}
+
+function isColumnMeta(value: unknown): value is ColumnMeta {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "dataType" in value &&
+    typeof value.dataType === "string" &&
+    "name" in value &&
+    typeof value.name === "string"
+  );
 }

--- a/packages/ui/src/fields/number-field.tsx
+++ b/packages/ui/src/fields/number-field.tsx
@@ -28,6 +28,11 @@ export function NumberField({
     return <span>—</span>;
   }
 
+  const num = typeof value === "number" ? value : Number(value);
+  if (Number.isNaN(num)) {
+    return <span>—</span>;
+  }
+
   const options: Intl.NumberFormatOptions = {};
   if (currency) {
     options.style = "currency";
@@ -38,6 +43,6 @@ export function NumberField({
     options.maximumFractionDigits = decimals;
   }
 
-  const formatted = new Intl.NumberFormat(locale, options).format(value);
+  const formatted = new Intl.NumberFormat(locale, options).format(num);
   return <span>{formatted}</span>;
 }

--- a/packages/ui/src/fields/relation-field.tsx
+++ b/packages/ui/src/fields/relation-field.tsx
@@ -1,4 +1,5 @@
 import type { RelationFieldProps } from "../types.js";
+import { getField } from "../record-access.js";
 
 /**
  * Read-only display component for related record references.
@@ -27,9 +28,13 @@ export function RelationField({
     return <span>—</span>;
   }
 
-  const record = value as Record<string, unknown>;
-  const displayValue = String(record[display] ?? record.id ?? value);
-  const id = record.id as string | undefined;
+  if (typeof value !== "object" || value === null) {
+    return <span>{String(value)}</span>;
+  }
+
+  const displayValue = String(getField(value, display) ?? getField(value, "id") ?? value);
+  const rawId = getField(value, "id");
+  const id = typeof rawId === "string" ? rawId : undefined;
 
   if (linkTo && id) {
     const href = linkTo.replace(":id", id);

--- a/packages/ui/src/fields/text-field.tsx
+++ b/packages/ui/src/fields/text-field.tsx
@@ -24,12 +24,13 @@ export function TextField({
     return <span>—</span>;
   }
 
-  const display = maxLength && value.length > maxLength
-    ? `${value.slice(0, maxLength)}…`
-    : value;
+  const text = String(value);
+  const display = maxLength && text.length > maxLength
+    ? `${text.slice(0, maxLength)}…`
+    : text;
 
-  if (maxLength && value.length > maxLength) {
-    return <span title={value}>{display}</span>;
+  if (maxLength && text.length > maxLength) {
+    return <span title={text}>{display}</span>;
   }
 
   return <span>{display}</span>;

--- a/packages/ui/src/joy/data-table.tsx
+++ b/packages/ui/src/joy/data-table.tsx
@@ -4,6 +4,7 @@ import JoySheet from "@mui/joy/Sheet";
 import JoyCheckbox from "@mui/joy/Checkbox";
 
 import type { DataTableProps, ColumnDef, ColumnShorthand } from "../types.js";
+import { getField, getRecordId } from "../record-access.js";
 
 function normalizeColumns<T>(columns: ColumnShorthand<T>[] | undefined): ColumnDef<T>[] {
   if (!columns) return [];
@@ -120,6 +121,7 @@ export function DataTable<T = unknown>({
               >
                 {selectable ? (
                   <td>
+                    {/* MUI polymorphic component workaround — literal types required */}
                     <JoyCheckbox
                       checked={isSelected}
                       onChange={() => toggleRow(id)}
@@ -128,7 +130,7 @@ export function DataTable<T = unknown>({
                   </td>
                 ) : null}
                 {columns.map((col) => {
-                  const value = (row as Record<string, unknown>)[col.key];
+                  const value = getField(row, col.key);
                   return (
                     <td key={col.key}>
                       {col.render ? col.render(value, row) : String(value ?? "")}
@@ -145,5 +147,5 @@ export function DataTable<T = unknown>({
 }
 
 function defaultGetId<T>(row: T): string | number {
-  return (row as Record<string, unknown>).id as string | number;
+  return getRecordId(row);
 }

--- a/packages/ui/src/joy/detail-view.tsx
+++ b/packages/ui/src/joy/detail-view.tsx
@@ -4,6 +4,7 @@ import JoyTypography from "@mui/joy/Typography";
 import { PageContainer } from "./page-container.js";
 import { fieldForColumn } from "../fields/field-for-column.js";
 import type { DetailViewProps, ColumnDef, ColumnShorthand } from "../types.js";
+import { getField } from "../record-access.js";
 
 function normalizeFields<T>(
   fields: ColumnShorthand<T>[] | undefined,
@@ -45,13 +46,14 @@ export function DetailView<T = unknown>({
     <PageContainer title={title} breadcrumb={breadcrumb}>
       <JoyGrid container spacing={2}>
         {displayFields.map((field) => {
-          const value = (record as Record<string, unknown>)[field.key];
+          const value = getField(record, field.key);
           const FieldComponent = field.render
             ? null
             : resolveFieldComponent(field.key, table);
 
           return (
             <JoyGrid key={field.key} xs={12} md={6}>
+              {/* MUI polymorphic component workaround — literal types required */}
               <JoyTypography
                 level={"body-xs" as const}
                 textTransform={"uppercase" as const}
@@ -81,7 +83,7 @@ function inferFieldsFromRecord<T>(
 ): ColumnDef<T>[] {
   if (!record || typeof record !== "object") return [];
 
-  return Object.keys(record as Record<string, unknown>)
+  return Object.keys(record)
     .filter((key) => !exclude || !exclude.includes(key))
     .map((key) => ({
       key,
@@ -98,11 +100,17 @@ function resolveFieldComponent(
 ): ReturnType<typeof fieldForColumn> | null {
   if (!table || typeof table !== "object") return null;
 
-  const col = (table as Record<string, unknown>)[_key];
-  if (!col || typeof col !== "object" || !("dataType" in col) || !("name" in col)) {
+  const col = getField(table, _key);
+  if (
+    !col ||
+    typeof col !== "object" ||
+    !("dataType" in col) ||
+    typeof col.dataType !== "string" ||
+    !("name" in col) ||
+    typeof col.name !== "string"
+  ) {
     return null;
   }
 
-  const meta = col as { dataType: string; name: string };
-  return fieldForColumn(meta);
+  return fieldForColumn({ dataType: col.dataType, name: col.name });
 }

--- a/packages/ui/src/joy/image-preview.tsx
+++ b/packages/ui/src/joy/image-preview.tsx
@@ -22,9 +22,10 @@ export function ImagePreview({
       <div>{fallback}</div>
     ) : (
       <JoyAspectRatio
-        ratio={`${width}/${height}` as unknown as number}
+        ratio={width / height}
         sx={{ width, borderRadius: "sm", bgcolor: "neutral.softBg" }}
       >
+        {/* MUI polymorphic component workaround — literal types required */}
         <JoyTypography level={"body-sm" as const} color={"neutral" as const}>
           No image
         </JoyTypography>
@@ -34,7 +35,7 @@ export function ImagePreview({
 
   return (
     <JoyAspectRatio
-      ratio={`${width}/${height}` as unknown as number}
+      ratio={width / height}
       sx={{ width, borderRadius: "sm", overflow: "hidden" }}
     >
       <img

--- a/packages/ui/src/joy/role-badge.tsx
+++ b/packages/ui/src/joy/role-badge.tsx
@@ -3,6 +3,8 @@ import Chip from "@mui/joy/Chip";
 import type { ColorPaletteProp } from "@mui/joy/styles";
 import type { RoleBadgeProps } from "../types.js";
 
+const VALID_COLORS = new Set<string>(["primary", "neutral", "danger", "success", "warning"]);
+
 const defaultColors: Record<string, ColorPaletteProp> = {
   admin: "danger",
   editor: "primary",
@@ -10,16 +12,16 @@ const defaultColors: Record<string, ColorPaletteProp> = {
   reader: "neutral",
 };
 
+function isColorPaletteProp(value: string): value is ColorPaletteProp {
+  return VALID_COLORS.has(value);
+}
+
 /**
  * Joy UI RoleBadge — MUI Joy Chip with configurable color per role.
  */
 export function RoleBadge({ role, colors }: RoleBadgeProps): ReactElement {
-  const colorMap = colors
-    ? { ...defaultColors, ...Object.fromEntries(
-        Object.entries(colors).map(([k, v]) => [k, v as ColorPaletteProp]),
-      )}
-    : defaultColors;
-  const chipColor = colorMap[role] ?? ("neutral" satisfies ColorPaletteProp);
+  const rawColor = colors?.[role] ?? defaultColors[role] ?? "neutral";
+  const chipColor: ColorPaletteProp = isColorPaletteProp(rawColor) ? rawColor : "neutral";
 
   return (
     <Chip size="sm" variant="soft" color={chipColor}>

--- a/packages/ui/src/plugin.tsx
+++ b/packages/ui/src/plugin.tsx
@@ -120,11 +120,10 @@ export function useComponent<K extends keyof UIPluginComponents>(
   slot: K,
 ): UIPluginComponents[K] {
   const plugin = useUIPlugin();
-  const component = plugin?.components[slot];
-  if (component) {
-    return component as UIPluginComponents[K];
-  }
-  return headlessDefaults[slot] as UIPluginComponents[K];
+  // Spread the full defaults with any plugin overrides so the indexed access
+  // resolves to the concrete UIPluginComponents[K] without a cast.
+  const merged: UIPluginComponents = { ...headlessDefaults, ...plugin?.components };
+  return merged[slot];
 }
 
 // Re-export for convenience

--- a/packages/ui/src/record-access.ts
+++ b/packages/ui/src/record-access.ts
@@ -1,0 +1,41 @@
+/**
+ * Safely retrieves a property from an unknown record-like value by string key.
+ *
+ * Isolates the single unavoidable `Record<string, unknown>` assertion needed
+ * when accessing dynamic keys on generic row/record objects (e.g., in DataTable
+ * and DetailView). Using this helper keeps the rest of the codebase cast-free.
+ *
+ * Returns `undefined` for non-object or null values.
+ *
+ * @param obj - A value expected to be a record-like object.
+ * @param key - The property name to look up.
+ * @returns The property value, or `undefined` if the key does not exist or obj is not an object.
+ *
+ * @internal
+ */
+export function getField(obj: unknown, key: string): unknown {
+  if (typeof obj !== "object" || obj === null) {
+    return undefined;
+  }
+  // Single isolation point for dynamic key access on generic objects
+  return (obj as Record<string, unknown>)[key];
+}
+
+/**
+ * Extracts a string or number `id` from an unknown value.
+ *
+ * Returns the `id` property when it is a `string` or `number`, otherwise
+ * falls back to `0`. Isolates the dynamic-key access so callers avoid casts.
+ *
+ * @param obj - A value expected to be a record-like object with an `id` property.
+ * @returns The `id` value as a `string | number`, or `0` if missing/wrong type.
+ *
+ * @internal
+ */
+export function getRecordId(obj: unknown): string | number {
+  const id = getField(obj, "id");
+  if (typeof id === "string" || typeof id === "number") {
+    return id;
+  }
+  return 0;
+}

--- a/packages/ui/src/types.ts
+++ b/packages/ui/src/types.ts
@@ -665,6 +665,18 @@ export type BaseFieldProps = {
 };
 
 /**
+ * A field component that can be rendered with an unknown value.
+ *
+ * Used as the return type of {@link fieldForColumn} and {@link fieldsForTable}
+ * where the concrete value type is not known at lookup time. Internally each
+ * field implementation narrows the value to its expected type and handles
+ * invalid input gracefully.
+ *
+ * @see {@link BaseFieldProps} for the inherited label and className props.
+ */
+export type FieldComponent = ComponentType<BaseFieldProps & { value: unknown }>;
+
+/**
  * Props for the DateField read-only display component.
  *
  * Formats dates using `Intl.DateTimeFormat` with support for relative time display.
@@ -673,8 +685,8 @@ export type BaseFieldProps = {
  * @see {@link BaseFieldProps} for inherited label and className props.
  */
 export type DateFieldProps = BaseFieldProps & {
-  /** Date value to display. Accepts Date objects, ISO strings, or timestamps. */
-  value: Date | string | number | null | undefined;
+  /** Date value to display. Accepts Date objects, ISO strings, timestamps, or unknown values. */
+  value: unknown;
   /** Display format. Defaults to "short". */
   format?: "short" | "long" | "relative" | "datetime";
   /** Locale for date formatting. Defaults to "en". */
@@ -691,8 +703,8 @@ export type DateFieldProps = BaseFieldProps & {
  * @see {@link ChipSlotProps} for the underlying chip slot.
  */
 export type BooleanFieldProps = BaseFieldProps & {
-  /** Boolean value to display. */
-  value: boolean | null | undefined;
+  /** Boolean value to display. Accepts booleans or unknown values. */
+  value: unknown;
   /** Label shown when value is true. Defaults to "Yes". */
   trueLabel?: string;
   /** Label shown when value is false. Defaults to "No". */
@@ -712,8 +724,8 @@ export type BooleanFieldProps = BaseFieldProps & {
  * @see {@link BaseFieldProps} for inherited label and className props.
  */
 export type NumberFieldProps = BaseFieldProps & {
-  /** Numeric value to display. */
-  value: number | null | undefined;
+  /** Numeric value to display. Accepts numbers or unknown values. */
+  value: unknown;
   /** Locale for number formatting. Defaults to "en". */
   locale?: string;
   /** ISO 4217 currency code for monetary formatting (e.g. "USD"). */
@@ -732,8 +744,8 @@ export type NumberFieldProps = BaseFieldProps & {
  * @see {@link BaseFieldProps} for inherited label and className props.
  */
 export type TextFieldProps = BaseFieldProps & {
-  /** Text value to display. */
-  value: string | null | undefined;
+  /** Text value to display. Accepts strings or unknown values. */
+  value: unknown;
   /** Maximum display length; longer values are truncated with a tooltip. */
   maxLength?: number;
   /** Whether to show a copy-to-clipboard button. */
@@ -748,8 +760,8 @@ export type TextFieldProps = BaseFieldProps & {
  * @see {@link BaseFieldProps} for inherited label and className props.
  */
 export type EmailFieldProps = BaseFieldProps & {
-  /** Email address to display as a mailto link. */
-  value: string | null | undefined;
+  /** Email address to display as a mailto link. Accepts strings or unknown values. */
+  value: unknown;
 };
 
 /**


### PR DESCRIPTION
## Summary
- Replace `ComponentType<any>` in `fieldForColumn`/`fieldsForTable` with a proper `FieldComponent` type (`ComponentType<BaseFieldProps & { value: unknown }>`)
- Widen field component value props to `unknown` with runtime narrowing (String/Boolean/Number conversions with graceful fallback)
- Create `getField`/`getRecordId` helpers in `record-access.ts` to isolate the single unavoidable `Record<string, unknown>` assertion for dynamic key access, replacing inline `as Record<string, unknown>` casts across DataTable, DetailView, and RelationField
- Fix `image-preview.tsx`: replace `as unknown as number` with numeric division (`width / height`)
- Fix `role-badge.tsx` and `boolean-field.tsx`: replace `as ColorPaletteProp` / `as` union casts with type guard functions
- Fix `plugin.tsx`: eliminate `as UIPluginComponents[K]` casts by spreading defaults with overrides
- Document retained `as const` assertions on MUI Joy components with `// MUI polymorphic component workaround` comments

## Test plan
- [x] `pnpm --filter @cfast/ui typecheck` passes (same pre-existing errors as baseline)
- [x] `pnpm --filter @cfast/ui test` — all 125 tests pass; 4 pre-existing suite failures from unresolved `@cfast/auth/client` imports unchanged
- [ ] Verify field components still render correctly with actual data (storybook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)