### PR TITLE
fix: wait for hydration in profile E2E tests

### DIFF
--- a/examples/team-blog-after/e2e/profile-mutations.spec.ts
+++ b/examples/team-blog-after/e2e/profile-mutations.spec.ts
@@ -11,7 +11,7 @@ test.describe.serial("Profile Updates", () => {
 
   test("user can update their display name", async ({ page, context }) => {
     await loginAs(context, "reader");
-    await page.goto("/profile");
+    await page.goto("/profile", { waitUntil: "networkidle" });
 
     await page.fill('input[name="name"]', updatedName);
     await page.click('button:has-text("Update Profile")');
@@ -25,7 +25,7 @@ test.describe.serial("Profile Updates", () => {
 
   test("name field cannot be empty", async ({ page, context }) => {
     await loginAs(context, "reader");
-    await page.goto("/profile");
+    await page.goto("/profile", { waitUntil: "networkidle" });
 
     // Clear the name field
     const nameInput = page.locator('input[name="name"]');
@@ -41,7 +41,7 @@ test.describe.serial("Profile Updates", () => {
 
   test("updated name appears in header", async ({ page, context }) => {
     await loginAs(context, "reader");
-    await page.goto("/profile");
+    await page.goto("/profile", { waitUntil: "networkidle" });
 
     // Verify the name input has the updated value
     const nameInput = page.locator('input[name="name"]');

--- a/examples/team-blog-before/e2e/profile-mutations.spec.ts
+++ b/examples/team-blog-before/e2e/profile-mutations.spec.ts
@@ -11,7 +11,7 @@ test.describe.serial("Profile Updates", () => {
 
   test("user can update their display name", async ({ page, context }) => {
     await loginAs(context, "reader");
-    await page.goto("/profile");
+    await page.goto("/profile", { waitUntil: "networkidle" });
 
     await page.fill('input[name="name"]', updatedName);
     await page.click('button:has-text("Update Profile")');
@@ -25,7 +25,7 @@ test.describe.serial("Profile Updates", () => {
 
   test("name field cannot be empty", async ({ page, context }) => {
     await loginAs(context, "reader");
-    await page.goto("/profile");
+    await page.goto("/profile", { waitUntil: "networkidle" });
 
     // Clear the name field
     const nameInput = page.locator('input[name="name"]');
@@ -41,7 +41,7 @@ test.describe.serial("Profile Updates", () => {
 
   test("updated name appears in header", async ({ page, context }) => {
     await loginAs(context, "reader");
-    await page.goto("/profile");
+    await page.goto("/profile", { waitUntil: "networkidle" });
 
     // Verify the name input has the updated value
     const nameInput = page.locator('input[name="name"]');


### PR DESCRIPTION
## Summary
- Profile mutation E2E tests in both `team-blog-before` and `team-blog-after` were missing `waitUntil: "networkidle"` on `page.goto("/profile")`, unlike all other mutation tests that interact with forms
- On slower CI runners, `page.fill()` could run before React hydration completed, causing React to overwrite the input value during hydration — the form would submit with the unchanged original value, making the update a silent no-op
- Added `waitUntil: "networkidle"` to all `page.goto()` calls in profile mutation tests, matching the pattern used by every other mutation test

## Test plan
- [x] Verified both `team-blog-before` and `team-blog-after` profile E2E tests pass locally
- [ ] CI E2E tests should now pass on both examples

🤖 Generated with [Claude Code](https://claude.com/claude-code)