### PR TITLE
fix: use Node 22 for npm OIDC trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: pnpm
           registry-url: "https://registry.npmjs.org"
 


### PR DESCRIPTION
## Summary
- Upgrades Node.js from 20 to 22 in the release workflow
- npm OIDC trusted publishing requires npm CLI 11.5.1+ (Node 22.14.0+); Node 20 ships npm 10.x which doesn't support it, causing E404 errors on publish

## Test plan
- [ ] Verify trusted publishers are configured on npmjs.com for `create-cfast` and `@cfast/email`
- [ ] Merge and confirm the next release-please publish succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)