### PR TITLE
docs: rewrite getting started guide with scaffold-first approach

### DIFF
--- a/docs/website/src/content/docs/getting-started.mdx
+++ b/docs/website/src/content/docs/getting-started.mdx
@@ -26,24 +26,17 @@ This guide walks you through creating a CFast project and building a task manage
 
    When prompted, select all features (auth, permissions, db, ui, admin, email). The scaffolder generates a complete app with authentication, an admin panel, and an example `items` table.
 
-2. **Create the D1 database**
+2. **Run migrations and start the dev server**
 
    ```bash
    cd my-app
-   wrangler d1 create my-app-db
-   ```
-
-   Copy the `database_id` from the output into your `wrangler.jsonc`.
-
-3. **Run migrations and start the dev server**
-
-   ```bash
+   pnpm install
    pnpm db:generate
    pnpm db:migrate:local
    pnpm dev
    ```
 
-   Open [http://localhost:8787](http://localhost:8787). You have a running app with authentication, an admin panel at `/admin`, and an example `items` table.
+   Wrangler automatically creates a local D1 database from the binding in `wrangler.toml`. Open [http://localhost:8787](http://localhost:8787) — you have a running app with authentication, an admin panel at `/admin`, and an example `items` table.
 
 </Steps>
 


### PR DESCRIPTION
## Summary

- Replace manual setup boilerplate with `npm create cfast@latest` scaffold
- Add "Build Your First Feature" section that walks through a task manager showcasing permissions (row-level ownership filtering), actions (`createAction` + `composeActions`), auto forms (`AutoForm` with schema-driven validation and enum selects), and admin panel integration
- Previous guide only covered `@cfast/env` and `@cfast/db` with `unsafe()`, missing the core value propositions

## Test plan

- [ ] Verify MDX renders correctly in Starlight (`cd docs/website && pnpm build`)
- [ ] Verify code examples match actual cfast APIs (validated during review)
- [ ] Verify internal links resolve (`/tutorial/01-setup/`, `/guides/permissions/`, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)