### PR TITLE
fix: add missing /cfast/ base path to documentation links

### DIFF
--- a/docs/website/src/content/docs/getting-started.mdx
+++ b/docs/website/src/content/docs/getting-started.mdx
@@ -309,10 +309,10 @@ In about 80 lines of code across four files, you added a complete task manager w
 
 ## Next Steps
 
-- **[Tutorial: Build a Team Blog](/tutorial/01-setup/)** — Walk through building a complete app across 8 chapters covering auth, storage, and email.
+- **[Tutorial: Build a Team Blog](/cfast/tutorial/01-setup/)** — Walk through building a complete app across 8 chapters covering auth, storage, and email.
 - **Package guides** — Deep dives on each package:
-  - [Permissions](/guides/permissions/) — Role hierarchy, row-level filtering, structural checks
-  - [Actions](/guides/actions/) — Multi-action routes, composed workflows, client hooks
-  - [Forms](/guides/forms/) — Field customization, external form control, custom plugins
-  - [Database](/guides/db/) — Caching, pagination, transactions, composed operations
-  - [Admin](/guides/admin/) — Custom views, dashboard widgets, impersonation
+  - [Permissions](/cfast/guides/permissions/) — Role hierarchy, row-level filtering, structural checks
+  - [Actions](/cfast/guides/actions/) — Multi-action routes, composed workflows, client hooks
+  - [Forms](/cfast/guides/forms/) — Field customization, external form control, custom plugins
+  - [Database](/cfast/guides/db/) — Caching, pagination, transactions, composed operations
+  - [Admin](/cfast/guides/admin/) — Custom views, dashboard widgets, impersonation


### PR DESCRIPTION
## Summary
- Fix 6 broken documentation links in the getting-started page that were missing the `/cfast/` base path prefix
- All links pointed to `/guides/*` or `/tutorial/*` instead of `/cfast/guides/*` or `/cfast/tutorial/*`, causing 404s

## Test plan
- [ ] CI link checker passes with 0 broken links

🤖 Generated with [Claude Code](https://claude.com/claude-code)