### PR TITLE
fix: upgrade pnpm to 10.32.1 for OIDC trusted publishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "typescript": "^5.7",
     "typescript-eslint": "^8.57.0"
   },
-  "packageManager": "pnpm@10.17.1",
+  "packageManager": "pnpm@10.32.1+sha512.a706938f0e89ac1456b6563eab4edf1d1faf3368d1191fc5c59790e96dc918e4456ab2e67d613de1043d2e8c81f87303e6b40d4ffeca9df15ef1ad567348f2be",
   "engines": {
     "node": ">=20"
   }


### PR DESCRIPTION
## Summary
- Upgrades pnpm from 10.17.1 to 10.32.1
- pnpm added OIDC trusted publishing support in 10.20 — the old version could not perform the OIDC token exchange, causing all npm publishes to fail with E404
- Verified that trusted publishers are correctly configured on npmjs.com for all packages

## Context
The release workflow uses `pnpm publish --provenance` with `id-token: write` for OIDC-based authentication. While the npm-side trusted publisher config was correct, pnpm 10.17.1 predates OIDC support, so it sent unauthenticated requests (npm masks 401 as 404).

Failed run: https://github.com/DanielMSchmidt/cfast/actions/runs/23388369703/job/68038978941

## Test plan
- [ ] Merge and verify the next release-please publish succeeds
- [ ] Confirm provenance attestations appear on published packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)