### PR TITLE
chore: minor release for all packages

### DIFF
--- a/.changeset/release-all-minor.md
+++ b/.changeset/release-all-minor.md
@@ -1,0 +1,17 @@
+---
+"@cfast/actions": minor
+"@cfast/admin": minor
+"@cfast/auth": minor
+"@cfast/core": minor
+"@cfast/db": minor
+"@cfast/email": minor
+"@cfast/env": minor
+"@cfast/forms": minor
+"@cfast/pagination": minor
+"@cfast/permissions": minor
+"@cfast/storage": minor
+"@cfast/ui": minor
+"create-cfast": minor
+---
+
+Release all packages with minor version bump to reflect release process fix.


### PR DESCRIPTION
## Summary
- Adds a changeset to bump all 13 packages to the next minor version
- Packages bumped: `@cfast/actions`, `@cfast/admin`, `@cfast/auth`, `@cfast/core`, `@cfast/db`, `@cfast/email`, `@cfast/env`, `@cfast/forms`, `@cfast/pagination`, `@cfast/permissions`, `@cfast/storage`, `@cfast/ui`, `create-cfast`

## Test plan
- [ ] CI passes (build, lint, test)
- [ ] Merge triggers `changeset version` + `changeset publish` in the release workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)