### PR TITLE
feat: upgrade to Node 24 for npm OIDC publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           cache: pnpm
           registry-url: "https://registry.npmjs.org"
 

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,15 +1,15 @@
 {
-  "packages/actions": "0.1.0",
-  "packages/admin": "0.1.0",
-  "packages/auth": "0.1.0",
-  "packages/core": "0.1.0",
-  "packages/create-cfast": "0.1.0",
-  "packages/db": "0.1.0",
-  "packages/email": "0.1.0",
-  "packages/env": "0.1.0",
-  "packages/forms": "0.1.0",
-  "packages/pagination": "0.1.0",
-  "packages/permissions": "0.1.0",
-  "packages/storage": "0.1.0",
-  "packages/ui": "0.1.0"
+  "packages/actions": "0.0.3",
+  "packages/admin": "0.0.1",
+  "packages/auth": "0.0.3",
+  "packages/core": "0.0.1",
+  "packages/create-cfast": "0.0.4",
+  "packages/db": "0.0.3",
+  "packages/email": "0.0.3",
+  "packages/env": "0.0.1",
+  "packages/forms": "0.0.1",
+  "packages/pagination": "0.0.1",
+  "packages/permissions": "0.0.3",
+  "packages/storage": "0.0.1",
+  "packages/ui": "0.0.1"
 }

--- a/packages/actions/package.json
+++ b/packages/actions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cfast/actions",
-  "version": "0.1.0",
+  "version": "0.0.3",
   "description": "Multi-action routes and permission-aware action definitions for React Router",
   "keywords": [
     "cfast",

--- a/packages/admin/package.json
+++ b/packages/admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cfast/admin",
-  "version": "0.1.0",
+  "version": "0.0.1",
   "description": "Auto-generated admin UI from your Drizzle schema with role management and impersonation",
   "keywords": [
     "cfast",

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cfast/auth",
-  "version": "0.1.0",
+  "version": "0.0.3",
   "description": "Authentication for Cloudflare Workers: magic email, passkeys, roles, and impersonation",
   "keywords": [
     "cfast",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cfast/core",
-  "version": "0.1.0",
+  "version": "0.0.1",
   "description": "App composition layer with plugin system for @cfast/* packages",
   "keywords": [
     "cfast",

--- a/packages/create-cfast/package.json
+++ b/packages/create-cfast/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-cfast",
-  "version": "0.1.0",
+  "version": "0.0.4",
   "description": "Scaffold a fully wired Cloudflare Workers + React Router project with cfast",
   "keywords": [
     "cfast",

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cfast/db",
-  "version": "0.1.0",
+  "version": "0.0.3",
   "description": "Permission-aware Drizzle queries for Cloudflare D1",
   "keywords": [
     "cfast",

--- a/packages/email/package.json
+++ b/packages/email/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cfast/email",
-  "version": "0.1.0",
+  "version": "0.0.3",
   "description": "Plugin-based email for Cloudflare Workers with react-email rendering",
   "keywords": [
     "cfast",

--- a/packages/env/package.json
+++ b/packages/env/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cfast/env",
-  "version": "0.1.0",
+  "version": "0.0.1",
   "description": "Type-safe Cloudflare Worker bindings with runtime validation",
   "keywords": [
     "cfast",

--- a/packages/forms/package.json
+++ b/packages/forms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cfast/forms",
-  "version": "0.1.0",
+  "version": "0.0.1",
   "description": "Auto-generated forms from Drizzle schema with progressive customization",
   "keywords": [
     "cfast",

--- a/packages/pagination/package.json
+++ b/packages/pagination/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cfast/pagination",
-  "version": "0.1.0",
+  "version": "0.0.1",
   "description": "Cursor-based, offset-based pagination and infinite scroll for React Router",
   "keywords": [
     "cfast",

--- a/packages/permissions/package.json
+++ b/packages/permissions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cfast/permissions",
-  "version": "0.1.0",
+  "version": "0.0.3",
   "description": "Isomorphic, composable permission system with Drizzle-native row-level access control",
   "keywords": [
     "cfast",

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cfast/storage",
-  "version": "0.1.0",
+  "version": "0.0.1",
   "description": "Type-safe file uploads to Cloudflare R2 with multipart support and a schema-driven routing API",
   "keywords": [
     "cfast",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cfast/ui",
-  "version": "0.1.0",
+  "version": "0.0.1",
   "description": "Permission-aware React components with UI library plugins",
   "keywords": [
     "cfast",


### PR DESCRIPTION
## Summary
- **Upgrade publish job to Node 24** — npm OIDC trusted publishing requires npm CLI v11.5.1+, but Node 22 ships with npm v10.9.4 which silently fails the OIDC handshake (E404)
- **Reset versions** to pre-0.1.0 after deleting failed 0.1.0 GitHub releases (v0.1.0 was never published to npm)
- Combined with the `NODE_AUTH_TOKEN: ""` fix already on main, this completes the OIDC publishing fix

## Root cause
Two issues caused all 13 packages to fail with `E404 Not Found - PUT`:
1. **npm v10 doesn't support OIDC trusted publishing** — Node 22 ships with npm 10.9.4, but the OIDC handshake requires npm 11.5.1+
2. **`setup-node` sets `NODE_AUTH_TOKEN` to the GitHub token** — already fixed in PR #73

## After merge
1. Release-please sees `feat:` commit + manifest at pre-0.1.0 → creates release PR bumping to 0.1.0
2. Merge that release PR → publish runs with Node 24 (npm v11) + cleared auth token → OIDC succeeds → packages publish to npm

## Test plan
- [ ] CI passes
- [ ] After merge, release-please creates a "chore: release main" PR
- [ ] After merging the release PR, all 13 packages publish to npm via OIDC

🤖 Generated with [Claude Code](https://claude.com/claude-code)