### PR TITLE
fix: log full HTML body in email console provider

### DIFF
--- a/packages/email/src/__tests__/console.test.ts
+++ b/packages/email/src/__tests__/console.test.ts
@@ -24,6 +24,27 @@ describe("console provider", () => {
     const output = spy.mock.calls.map((c) => c.join(" ")).join("\n");
     expect(output).toContain("user@example.com");
     expect(output).toContain("Test Email");
+    expect(output).toContain("<p>Hello</p>");
+
+    spy.mockRestore();
+  });
+
+  it("logs full HTML body including links", async () => {
+    const spy = vi.spyOn(globalThis.console, "log").mockImplementation(() => {});
+
+    const provider = consoleDev();
+    const magicLink = "https://example.com/auth/magic?token=abc123";
+    await provider.send({
+      to: "user@example.com",
+      from: "noreply@example.com",
+      subject: "Sign in",
+      html: `<html><body><a href="${magicLink}">Sign in</a></body></html>`,
+      text: `Sign in: ${magicLink}`,
+    });
+
+    const output = spy.mock.calls.map((c) => c.join(" ")).join("\n");
+    expect(output).toContain(magicLink);
+    expect(output).toContain("<a href=");
 
     spy.mockRestore();
   });

--- a/packages/email/src/console.ts
+++ b/packages/email/src/console.ts
@@ -29,7 +29,7 @@ export function console(): EmailProvider {
         `  To: ${message.to}\n` +
         `  From: ${message.from}\n` +
         `  Subject: ${message.subject}\n` +
-        `  HTML: ${message.html.length} chars\n`,
+        `  HTML:\n${message.html}\n`,
       );
 
       return { id };


### PR DESCRIPTION
## Summary
- The `@cfast/email` console provider now logs the full HTML body instead of just the character count
- This makes magic-auth links visible in the terminal during local development

## Test plan
- [x] Added test case verifying HTML content (including links) appears in console output
- [x] Existing tests updated to assert HTML body is logged
- [x] All 18 email package tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)