### PR TITLE
fix(admin, create-cfast): fix type cast and introspectSchema resilience

### DIFF
--- a/packages/admin/src/__tests__/introspect.test.ts
+++ b/packages/admin/src/__tests__/introspect.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { sqliteTable, text, integer } from "drizzle-orm/sqlite-core";
+import { relations } from "drizzle-orm";
 import {
   introspectSchema,
   tableNameToLabel,
@@ -311,5 +312,37 @@ describe("introspectSchema", () => {
     const result = introspectSchema({ posts }, { posts: overrides });
 
     expect(result[0].overrides).toBe(overrides);
+  });
+
+  it("skips Relations exports without throwing", () => {
+    const usersRelations = relations(users, ({ many }) => ({
+      posts: many(posts),
+    }));
+
+    const schema = {
+      users,
+      posts,
+      usersRelations,
+    };
+
+    const result = introspectSchema(schema);
+    const names = result.map((t) => t.name);
+    expect(names).toContain("users");
+    expect(names).toContain("posts");
+    expect(names).not.toContain("usersRelations");
+    expect(result).toHaveLength(2);
+  });
+
+  it("skips non-table values like strings, functions, and plain objects", () => {
+    const schema = {
+      users,
+      helperFn: () => "not a table",
+      someConstant: "a string",
+      someObject: { foo: "bar" },
+    };
+
+    const result = introspectSchema(schema as Record<string, unknown>);
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe("users");
   });
 });

--- a/packages/admin/src/introspect.ts
+++ b/packages/admin/src/introspect.ts
@@ -1,6 +1,7 @@
 import type { SQLiteTable } from "drizzle-orm/sqlite-core";
 import { getTableConfig } from "drizzle-orm/sqlite-core";
 import { getTableColumns, getTableName } from "drizzle-orm";
+import { isTable } from "drizzle-orm";
 import type {
   AdminColumnConfig,
   AdminTableMeta,
@@ -125,12 +126,17 @@ export function columnNameToLabel(name: string): string {
  * ```
  */
 export function introspectSchema(
-  schema: Record<string, SQLiteTable>,
+  schema: Record<string, unknown>,
   tableOverrides?: Record<string, TableOverrides>,
 ): AdminTableMeta[] {
   const result: AdminTableMeta[] = [];
 
-  for (const [_key, table] of Object.entries(schema)) {
+  for (const [_key, value] of Object.entries(schema)) {
+    // Skip non-table exports (e.g. Relations, helper functions, constants)
+    if (!isTable(value)) {
+      continue;
+    }
+    const table = value as SQLiteTable;
     const tableName = getTableName(table);
     const overrides = tableOverrides?.[tableName] ?? {};
 

--- a/packages/admin/src/loader.ts
+++ b/packages/admin/src/loader.ts
@@ -1,4 +1,4 @@
-import { getTableColumns, getTableName, eq, like, or, asc, desc } from "drizzle-orm";
+import { getTableColumns, getTableName, eq, like, or, asc, desc, isTable } from "drizzle-orm";
 import type { SQL } from "drizzle-orm";
 import type { SQLiteTable } from "drizzle-orm/sqlite-core";
 import type { Db } from "@cfast/db";
@@ -94,11 +94,12 @@ function getColumn(drizzleTable: SQLiteTable, columnName: string) {
 /**
  * Find the users table in the schema by looking for a table named "user" or "users".
  */
-function findUsersTable(schema: Record<string, SQLiteTable>): SQLiteTable | undefined {
-  for (const table of Object.values(schema)) {
-    const name = getTableName(table);
+function findUsersTable(schema: Record<string, unknown>): SQLiteTable | undefined {
+  for (const value of Object.values(schema)) {
+    if (!isTable(value)) continue;
+    const name = getTableName(value);
     if (name === "user" || name === "users") {
-      return table;
+      return value as SQLiteTable;
     }
   }
   return undefined;

--- a/packages/admin/src/types.ts
+++ b/packages/admin/src/types.ts
@@ -301,8 +301,8 @@ export type AdminConfig = {
   db: CreateDbFn;
   /** Auth adapter that provides user authentication, role management, and impersonation. See {@link AdminAuthConfig}. */
   auth: AdminAuthConfig;
-  /** Your Drizzle schema object (e.g., `import * as schema from "~/schema"`). Tables are introspected from this. */
-  schema: Record<string, SQLiteTable>;
+  /** Your Drizzle schema object (e.g., `import * as schema from "~/schema"`). Non-table exports (Relations, helpers) are silently skipped. */
+  schema: Record<string, unknown>;
   /** Per-table display and behavior overrides, keyed by table name. See {@link TableOverrides}. */
   tables?: Record<string, TableOverrides>;
   /** Configuration for the built-in user management views. See {@link UserManagementConfig}. */

--- a/packages/create-cfast/src/__tests__/generators.test.ts
+++ b/packages/create-cfast/src/__tests__/generators.test.ts
@@ -164,6 +164,16 @@ describe("generateCfastServer", () => {
     expect(result).toContain("dbPlugin");
     expect(result).toContain("createDb");
   });
+
+  it("casts schema to Record<string, object> (not Record<string, unknown>)", () => {
+    const config = {
+      ...baseConfig,
+      features: { ...baseConfig.features, db: true },
+    };
+    const result = generateCfastServer(config);
+    expect(result).toContain("Record<string, object>");
+    expect(result).not.toContain("Record<string, unknown>");
+  });
 });
 
 describe("generateViteConfig", () => {

--- a/packages/create-cfast/src/generators/cfast-server.ts
+++ b/packages/create-cfast/src/generators/cfast-server.ts
@@ -47,7 +47,7 @@ const dbPlugin = definePlugin<AuthProvides>()({
   setup(ctx) {
     const client = createDb({
       d1: ctx.env.DB as D1Database,
-      schema: schema as unknown as Record<string, unknown>,
+      schema: schema as unknown as Record<string, object>,
       grants: ctx.auth.grants,
       user: ctx.auth.user ? { id: ctx.auth.user.id } : null,
       cache: false,
@@ -62,7 +62,7 @@ const dbPlugin = definePlugin({
   setup(ctx) {
     const client = createDb({
       d1: ctx.env.DB as D1Database,
-      schema: schema as unknown as Record<string, unknown>,
+      schema: schema as unknown as Record<string, object>,
       grants: [],
       user: null,
       cache: false,


### PR DESCRIPTION
## Summary
- Fix wrong type cast in create-cfast generated `cfast.server.ts` (`Record<string, unknown>` → `Record<string, object>`) to match `DbConfig["schema"]` which expects `Record<string, DrizzleTable>` (alias for `Record<string, object>`)
- Make `@cfast/admin` `introspectSchema` resilient to non-table schema exports (Relations, helper functions, constants) by using drizzle-orm's `isTable()` guard to skip non-table entries
- Update `AdminConfig.schema` type from `Record<string, SQLiteTable>` to `Record<string, unknown>` so callers can pass `import * as schema` directly without filtering
- Update internal `findUsersTable` in loader to also use `isTable()` guard for consistency

Both bugs were surfaced by the **cfast-tracker** demo app.

## Demo app update task
- [ ] Update cfast-tracker: remove workaround cast in `app/cfast.server.ts`
- [ ] Update cfast-tracker: remove schema filtering in `app/routes/admin.tsx`

## Test plan
- [x] New test: `introspectSchema` skips Relations exports without throwing
- [x] New test: `introspectSchema` skips non-table values (strings, functions, plain objects)
- [x] New test: generated `cfast.server.ts` casts to `Record<string, object>` (not `unknown`)
- [x] All existing tests pass (32 introspect tests, 47 create-cfast tests)
- [x] Full CI: `pnpm typecheck` (37/37), `pnpm test` (28/28), `pnpm build` (25/25)
- [ ] Scaffold a new project with `create-cfast --all` and verify no type errors
- [ ] Verify `introspectSchema` works with `import * as schema` that includes Relations

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)