### PR TITLE
fix(docs): exclude test files from typedoc generation

### DIFF
--- a/docs/website/tsconfig.typedoc.json
+++ b/docs/website/tsconfig.typedoc.json
@@ -30,5 +30,10 @@
     },
     "types": ["@cloudflare/workers-types"]
   },
-  "include": ["../../packages/*/src/**/*.ts", "../../packages/*/src/**/*.tsx"]
+  "include": ["../../packages/*/src/**/*.ts", "../../packages/*/src/**/*.tsx"],
+  "exclude": [
+    "../../packages/*/src/**/__tests__/**",
+    "../../packages/*/src/**/*.test.ts",
+    "../../packages/*/src/**/*.test.tsx"
+  ]
 }


### PR DESCRIPTION
## Summary
- Typedoc/starlight was compiling test files via the tsconfig `include` glob, which surfaced TypeScript errors in local test files and broke the docs build.
- Test files are not part of the public API and should not appear in API reference docs.
- Adds `exclude` patterns for `__tests__/**` directories and `*.test.ts`/`*.test.tsx` files to `docs/website/tsconfig.typedoc.json`.

This is needed before merging release-please PR #96.

## Test plan
- [x] `pnpm test:docs` passes
- [x] `pnpm run build && pnpm run typecheck && pnpm run lint` passes
- [ ] CI green

Generated with [claude-flow](https://github.com/ruvnet/claude-flow)