### PR TITLE
fix(joy): republish to fix workspace:* in dependencies

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -8,6 +8,7 @@
   "packages/email": "0.1.1",
   "packages/env": "0.1.0",
   "packages/forms": "0.1.0",
+  "packages/joy": "0.0.1",
   "packages/pagination": "0.1.0",
   "packages/permissions": "0.1.0",
   "packages/storage": "0.1.0",

--- a/packages/joy/llms.txt
+++ b/packages/joy/llms.txt
@@ -106,3 +106,8 @@ import { ActionButton } from "@cfast/joy";
 - Forgetting `<ToastProvider>` in root layout -- `useToast()` and `useActionToast()` throw without it.
 - Forgetting `<ConfirmProvider>` -- `useConfirm()` and `ActionButton` with `confirmation` need it.
 - Passing raw data arrays to `DataTable` instead of a pagination result from `usePagination()`.
+
+## See Also
+
+- `@cfast/ui` -- Headless components that `@cfast/joy` styles with MUI Joy.
+- `@cfast/actions` -- Action handling consumed by `ActionButton` and `ActionForm`.

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -13,6 +13,7 @@
     "packages/email": { "component": "@cfast/email" },
     "packages/env": { "component": "@cfast/env" },
     "packages/forms": { "component": "@cfast/forms" },
+    "packages/joy": { "component": "@cfast/joy" },
     "packages/pagination": { "component": "@cfast/pagination" },
     "packages/permissions": { "component": "@cfast/permissions" },
     "packages/storage": { "component": "@cfast/storage" },


### PR DESCRIPTION
## Summary

Republish `@cfast/joy` so its dependency entries reference real semver versions instead of `workspace:*`.

The currently published `@cfast/joy@0.0.1` on npm has broken `dependencies`:

```json
{
  "@cfast/actions": "workspace:*",
  "@cfast/auth": "workspace:*",
  "@cfast/ui": "workspace:*"
}
```

This is because the previous release workflow used `npm publish`, which does not rewrite pnpm workspace protocol references. PR #116 switched the workflow to `pnpm publish`, which rewrites `workspace:*` to actual semver versions at publish time.

This PR also adds `@cfast/joy` to `release-please-config.json` and `.release-please-manifest.json` -- it was missing from release-please management entirely, which is why no automated bump had ever produced a working tarball.

## Test plan

- [ ] Merge this PR
- [ ] Wait for release-please to open the "chore: release main" PR with a `@cfast/joy` bump
- [ ] Merge the release-please PR
- [ ] Verify `npm view @cfast/joy@latest dependencies` shows real versions (no `workspace:*`)

Co-Authored-By: claude-flow <ruv@ruv.net>