### PR TITLE
fix(actions): republish to fix workspace:* in dependencies

### DIFF
--- a/packages/actions/llms.txt
+++ b/packages/actions/llms.txt
@@ -174,3 +174,8 @@ function PostActions({ postId }) {
 - Using `createAction` directly without first calling `createActions` to set up the factory. `createAction` is returned by `createActions`, not a standalone export.
 - Omitting the `_action` hidden input in forms when using `composeActions`. The discriminator field is required to route to the correct handler.
 - Calling `useActions` with the wrong descriptor. Use `composed.client` for composed actions, or `singleAction.client` for a single action.
+
+## See Also
+
+- `@cfast/db` -- Permission descriptors come from Operation results.
+- `@cfast/permissions` -- Defines the grants enforced by action permissions.


### PR DESCRIPTION
## Summary

Republish `@cfast/actions` so its dependency entries reference real semver versions instead of `workspace:*`.

The currently published `@cfast/actions` on npm has broken `dependencies`:

```json
{
  "@cfast/db": "workspace:*",
  "@cfast/permissions": "workspace:*"
}
```

This is because the previous release workflow used `npm publish`, which does not rewrite pnpm workspace protocol references. PR #116 switched the workflow to `pnpm publish`, which rewrites `workspace:*` to actual semver versions at publish time.

## Test plan

- [ ] Merge this PR
- [ ] Wait for release-please to open the "chore: release main" PR with a `@cfast/actions` bump
- [ ] Merge the release-please PR
- [ ] Verify `npm view @cfast/actions@latest dependencies` shows real versions (no `workspace:*`)

Co-Authored-By: claude-flow <ruv@ruv.net>