### PR TITLE
fix(admin): republish to fix workspace:* in dependencies

### DIFF
--- a/packages/admin/llms.txt
+++ b/packages/admin/llms.txt
@@ -165,3 +165,8 @@ const admin = createAdmin({
 - Not providing `impersonate`/`stopImpersonation` callbacks and expecting impersonation to work -- these are optional but required for that feature.
 - Trying to customize rendering by passing JSX to `createAdmin` -- instead, override fields via `TableOverrides.fields` (for forms) or use `@cfast/ui` components directly in custom routes.
 - Expecting auth-internal tables (`session`, `account`, `verification`, `passkey`) to show up -- they are auto-excluded. Set `exclude: false` in table overrides to show them.
+
+## See Also
+
+- `@cfast/forms` -- Schema-derived forms used for create/edit views.
+- `@cfast/ui` + `@cfast/joy` -- Headless components and Joy UI styling.


### PR DESCRIPTION
## Summary

Republish `@cfast/admin` so its dependency entries reference real semver versions instead of `workspace:*`.

The currently published `@cfast/admin` on npm has broken `dependencies`:

```json
{
  "@cfast/db": "workspace:*",
  "@cfast/forms": "workspace:*",
  "@cfast/permissions": "workspace:*",
  "@cfast/joy": "workspace:*",
  "@cfast/ui": "workspace:*"
}
```

This is because the previous release workflow used `npm publish`, which does not rewrite pnpm workspace protocol references. PR #116 switched the workflow to `pnpm publish`, which rewrites `workspace:*` to actual semver versions at publish time.

## Test plan

- [ ] Merge this PR
- [ ] Wait for release-please to open the "chore: release main" PR with a `@cfast/admin` bump
- [ ] Merge the release-please PR
- [ ] Verify `npm view @cfast/admin@latest dependencies` shows real versions (no `workspace:*`)

Co-Authored-By: claude-flow <ruv@ruv.net>