### PR TITLE
fix(auth): republish to fix workspace:* in dependencies

### DIFF
--- a/packages/auth/llms.txt
+++ b/packages/auth/llms.txt
@@ -214,3 +214,8 @@ await auth.removeRole(userId, "editor");
 - **Forgetting to add auth routes** -- The magic link callback and passkey endpoints need `authRoutes()` in your `routes.ts`.
 - **Using `unsafe()` instead of roles for admin** -- Admins should have a proper role with grants, not bypass permissions entirely.
 - **Not wrapping the app with `AuthClientProvider`** -- `useAuth()` and `LoginPage` require the provider at the app root.
+
+## See Also
+
+- `@cfast/permissions` -- Defines roles and grants resolved from the authenticated user.
+- `@cfast/db` -- Receives `grants` from auth to enforce permissions on queries.


### PR DESCRIPTION
## Summary

Republish `@cfast/auth` so its dependency entries reference real semver versions instead of `workspace:*`.

The currently published `@cfast/auth` on npm has broken `dependencies`:

```json
{ "@cfast/permissions": "workspace:*" }
```

This is because the previous release workflow used `npm publish`, which does not rewrite pnpm workspace protocol references. PR #116 switched the workflow to `pnpm publish`, which rewrites `workspace:*` to actual semver versions at publish time.

## Test plan

- [ ] Merge this PR
- [ ] Wait for release-please to open the "chore: release main" PR with a `@cfast/auth` bump
- [ ] Merge the release-please PR
- [ ] Verify `npm view @cfast/auth@latest dependencies` shows real versions (no `workspace:*`)

Co-Authored-By: claude-flow <ruv@ruv.net>