### PR TITLE
fix(core): republish to fix workspace:* in dependencies

### DIFF
--- a/packages/core/llms.txt
+++ b/packages/core/llms.txt
@@ -165,3 +165,8 @@ export const { createAction, composeActions } = createActions({
 - Calling `useApp()` outside `<app.Provider>` -- throws a context error.
 - Registering two plugins with the same `name` -- throws `CfastConfigError` at import time.
 - Doing expensive work in `setup()` -- it runs on every request. Move one-time init to the plugin factory (outer function).
+
+## See Also
+
+- `@cfast/env` -- Type-safe Cloudflare bindings validated by `app.init()`.
+- `@cfast/permissions` -- Grants resolved per-request and exposed via `app.context()`.


### PR DESCRIPTION
## Summary

Republish `@cfast/core` so its dependency entries reference real semver versions instead of `workspace:*`.

The currently published `@cfast/core` on npm has broken `dependencies`:

```json
{
  "@cfast/env": "workspace:*",
  "@cfast/permissions": "workspace:*"
}
```

This is because the previous release workflow used `npm publish`, which does not rewrite pnpm workspace protocol references. PR #116 switched the workflow to `pnpm publish`, which rewrites `workspace:*` to actual semver versions at publish time.

## Test plan

- [ ] Merge this PR
- [ ] Wait for release-please to open the "chore: release main" PR with a `@cfast/core` bump
- [ ] Merge the release-please PR
- [ ] Verify `npm view @cfast/core@latest dependencies` shows real versions (no `workspace:*`)

Co-Authored-By: claude-flow <ruv@ruv.net>