### PR TITLE
fix(db): republish to fix workspace:* in dependencies

### DIFF
--- a/packages/db/llms.txt
+++ b/packages/db/llms.txt
@@ -184,3 +184,8 @@ export async function action({ context, request }) {
 - **Using `import { posts }` instead of `import * as schema`** -- The `schema` config must be `import *` so Drizzle's relational API can look up tables by key name.
 - **Using `db.unsafe()` for admin endpoints** -- Use a role with `grant("manage", "all")` instead. Reserve `unsafe()` for genuinely user-less contexts (cron, migrations).
 - **Expecting relational `with` to have permission filters** -- Permission WHERE clauses only apply to the root table, not joined relations.
+
+## See Also
+
+- `@cfast/permissions` -- Defines the grants checked by every Operation.
+- `@cfast/actions` -- Surfaces Operation `.permissions` to the client.


### PR DESCRIPTION
## Summary

Republish `@cfast/db` so its dependency entries reference real semver versions instead of `workspace:*`.

The currently published `@cfast/db` on npm has broken `dependencies`:

```json
{ "@cfast/permissions": "workspace:*" }
```

This is because the previous release workflow used `npm publish`, which does not rewrite pnpm workspace protocol references. PR #116 switched the workflow to `pnpm publish`, which rewrites `workspace:*` to actual semver versions at publish time.

## Test plan

- [ ] Merge this PR
- [ ] Wait for release-please to open the "chore: release main" PR with a `@cfast/db` bump
- [ ] Merge the release-please PR
- [ ] Verify `npm view @cfast/db@latest dependencies` shows real versions (no `workspace:*`)

Co-Authored-By: claude-flow <ruv@ruv.net>