### PR TITLE
fix(ui): republish to fix workspace:* in dependencies

### DIFF
--- a/packages/ui/llms.txt
+++ b/packages/ui/llms.txt
@@ -157,3 +157,8 @@ useActionToast(composed.client, {
 - Forgetting `<ConfirmProvider>` -- `useConfirm()` and `ActionButton` with `confirmation` need it.
 - Passing raw data arrays to `DataTable` instead of a pagination result from `usePagination()`.
 - Using `whenForbidden="show"` on `ActionButton` when you mean `"disable"` -- `"show"` renders even when forbidden with no visual indicator.
+
+## See Also
+
+- `@cfast/joy` -- Drop-in MUI Joy plugin that styles `@cfast/ui` headless components.
+- `@cfast/actions` -- Provides the action descriptors consumed by `ActionButton`/`ActionForm`.


### PR DESCRIPTION
## Summary

Republish `@cfast/ui` so its dependency entries reference real semver versions instead of `workspace:*`.

The currently published `@cfast/ui` on npm has broken `dependencies`:

```json
{
  "@cfast/actions": "workspace:*",
  "@cfast/auth": "workspace:*",
  "@cfast/db": "workspace:*",
  "@cfast/pagination": "workspace:*",
  "@cfast/permissions": "workspace:*",
  "@cfast/storage": "workspace:*"
}
```

This is because the previous release workflow used `npm publish`, which does not rewrite pnpm workspace protocol references. PR #116 switched the workflow to `pnpm publish`, which rewrites `workspace:*` to actual semver versions at publish time.

## Test plan

- [ ] Merge this PR
- [ ] Wait for release-please to open the "chore: release main" PR with a `@cfast/ui` bump
- [ ] Merge the release-please PR
- [ ] Verify `npm view @cfast/ui@latest dependencies` shows real versions (no `workspace:*`)

Co-Authored-By: claude-flow <ruv@ruv.net>