### PR TITLE
feat(auth): ship test-helpers subpath with real-workflow session helpers

### DIFF
--- a/packages/auth/llms.txt
+++ b/packages/auth/llms.txt
@@ -161,6 +161,50 @@ export default [...authRoutes({ handlerFile: "routes/auth.$.tsx" }), ...otherRou
 
 Drizzle tables: `user`, `session`, `passkey`, `role`, `impersonation_log`.
 
+### Test helpers (`@cfast/auth/test-helpers`)
+
+Real-workflow helpers for driving the magic-link flow from tests. Every helper hits the actual Better Auth pipeline — no mocks, no hand-written session inserts — so a session produced by `loginAs()` is indistinguishable from one a user created by clicking a link in their inbox.
+
+```typescript
+import {
+  createTestApp,
+  loginAs,
+  createTestSession,
+  applyAuthSchema,
+} from "@cfast/auth/test-helpers";
+
+// 1. Spin up a real auth instance against a D1 binding (env.DB for
+//    vitest-pool-workers, or any other D1 you control).
+const app = await createTestApp({
+  d1: env.DB,
+  appUrl: env.APP_URL,
+  auth: { permissions, schema: authSchema, defaultRoles: ["user"] },
+});
+
+// 2. Log in as a user by completing the REAL magic-link flow:
+//    sendMagicLink -> capture URL -> issue verify request -> parse cookie.
+const { cookie, user, session } = await loginAs(app, {
+  email: "alice@test.com",
+  name: "Alice",
+  roles: ["editor"], // assigned via the real auth.setRole() API
+});
+
+// 3. Drive your production loaders with the helper's cookie — the same
+//    requireUser() call that runs in prod will authenticate it.
+const response = await loader({
+  request: new Request("http://localhost/dashboard", {
+    headers: { Cookie: cookie },
+  }),
+});
+
+// Lower-level: skip the email-send callback and mint a session via
+// auth.api.signInMagicLink directly. Same end result (real session row,
+// real cookie), just less surface area exercised.
+await createTestSession(app, { email: "bob@test.com", roles: ["admin"] });
+```
+
+`createTestApp` also exposes `capturedMagicLinks` and `waitForMagicLink(email?)` so tests can assert on the URLs Better Auth generates. Use `applyAuthSchema(d1)` to set up the tables if you want to manage lifecycle yourself and pass `applyMigrations: false`.
+
 ## Usage Examples
 
 ### Protect a layout route

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -34,6 +34,10 @@
     "./schema": {
       "import": "./dist/schema.js",
       "types": "./dist/schema.d.ts"
+    },
+    "./test-helpers": {
+      "import": "./dist/test-helpers/index.js",
+      "types": "./dist/test-helpers/index.d.ts"
     }
   },
   "files": [
@@ -45,8 +49,8 @@
     "access": "public"
   },
   "scripts": {
-    "build": "tsup src/index.ts src/client.ts src/plugin.ts src/schema.ts --format esm --dts",
-    "dev": "tsup src/index.ts src/client.ts src/plugin.ts src/schema.ts --format esm --dts --watch",
+    "build": "tsup src/index.ts src/client.ts src/plugin.ts src/schema.ts src/test-helpers/index.ts --format esm --dts",
+    "dev": "tsup src/index.ts src/client.ts src/plugin.ts src/schema.ts src/test-helpers/index.ts --format esm --dts --watch",
     "test": "vitest run",
     "typecheck": "tsc --noEmit",
     "lint": "eslint src/"

--- a/packages/auth/src/__tests__/test-helpers.test.ts
+++ b/packages/auth/src/__tests__/test-helpers.test.ts
@@ -1,0 +1,623 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { definePermissions, grant } from "@cfast/permissions";
+import { createMockD1 } from "./helpers";
+
+// Mock Better Auth so we can drive the test helpers deterministically
+// without needing a real D1 or real better-auth in the unit test pool.
+// The goal of these unit tests is to prove the HELPER LOGIC is correct:
+// - it wraps the user's sendMagicLink
+// - it calls signInMagicLink through the public API
+// - it issues a real handler() request against the verify endpoint
+// - it extracts the cookie, session row, user row correctly
+// The end-to-end "this produces a session indistinguishable from
+// production" proof lives in the integration test suite where a real
+// D1 and real better-auth run inside workerd.
+const {
+  mockSignInMagicLink,
+  mockHandler,
+  mockGetSession,
+  mockBetterAuth,
+} = vi.hoisted(() => {
+  const mockSignInMagicLink = vi.fn();
+  const mockHandler = vi.fn();
+  const mockGetSession = vi.fn();
+  const mockBetterAuth = vi.fn((_opts: Record<string, unknown>) => ({
+    api: {
+      getSession: mockGetSession,
+      signInMagicLink: mockSignInMagicLink,
+    },
+    handler: mockHandler,
+  }));
+  return { mockSignInMagicLink, mockHandler, mockGetSession, mockBetterAuth };
+});
+
+vi.mock("better-auth", () => ({
+  betterAuth: mockBetterAuth,
+}));
+
+vi.mock("better-auth/adapters/drizzle", () => ({
+  drizzleAdapter: vi.fn(() => ({})),
+}));
+
+vi.mock("better-auth/plugins/magic-link", () => ({
+  magicLink: vi.fn(
+    (opts: unknown) =>
+      ({ id: "magic-link", ...(opts as Record<string, unknown>) }),
+  ),
+}));
+
+vi.mock("@better-auth/passkey", () => ({
+  passkey: vi.fn((opts: unknown) => ({ id: "passkey", ...(opts as Record<string, unknown>) })),
+}));
+
+vi.mock("drizzle-orm/d1", () => ({
+  drizzle: vi.fn(() => ({})),
+}));
+
+// Import after mocks are set up.
+const { createTestApp, loginAs, createTestSession, applyAuthSchema } =
+  await import("../test-helpers");
+
+const permissions = definePermissions({
+  roles: ["reader", "editor"] as const,
+  grants: {
+    reader: [grant("read", "all")],
+    editor: [grant("read", "all"), grant("create", "all")],
+  },
+});
+
+type SeedSession = {
+  id: string;
+  user_id: string;
+  token: string;
+  expires_at: number;
+  email: string;
+  name: string;
+};
+
+/**
+ * Augments a mock D1 so its `prepare().bind().first()` returns a canned
+ * session row whenever the helper queries for the latest session. All
+ * other SELECT/INSERT/DELETE operations pass through to the default
+ * mock (which returns empty results and records the calls).
+ */
+function seedSessionRow(
+  d1: ReturnType<typeof createMockD1>,
+  row: SeedSession,
+) {
+  const originalPrepare = d1.prepare;
+  (d1 as unknown as Record<string, unknown>).prepare = (sql: string) => {
+    const stmt = (originalPrepare as (sql: string) => unknown)(sql);
+    if (sql.includes("FROM sessions") && sql.includes("INNER JOIN users")) {
+      return {
+        bind: () => ({
+          first: async () => row,
+          all: async () => ({ results: [row] }),
+          run: async () => ({ results: [] }),
+        }),
+      };
+    }
+    return stmt;
+  };
+}
+
+/**
+ * Builds a handler() mock that responds to the verify endpoint with a
+ * real Response carrying the given Set-Cookie header and JSON body.
+ */
+function stubVerifyHandler(
+  setCookieHeaders: string[] = [
+    "better-auth.session_token=token-abc; Path=/; HttpOnly; SameSite=Lax",
+  ],
+  body: Record<string, unknown> = {
+    token: "token-abc",
+    user: { id: "user-1", email: "alice@test.com", name: "Alice" },
+  },
+) {
+  mockHandler.mockImplementation(async (req: Request) => {
+    const url = new URL(req.url);
+    if (url.pathname.endsWith("/api/auth/magic-link/verify")) {
+      const headers = new Headers({ "content-type": "application/json" });
+      for (const h of setCookieHeaders) {
+        headers.append("set-cookie", h);
+      }
+      return new Response(JSON.stringify(body), {
+        status: 200,
+        headers,
+      });
+    }
+    return new Response("not found", { status: 404 });
+  });
+}
+
+describe("applyAuthSchema", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("runs an exec() for every auth table", async () => {
+    const d1 = createMockD1();
+    const execSpy = vi.spyOn(d1, "exec");
+    await applyAuthSchema(d1);
+    // users, sessions, accounts, verifications, passkeys, roles, impersonation_logs = 7
+    expect(execSpy).toHaveBeenCalledTimes(7);
+    const joined = execSpy.mock.calls.map((c) => c[0]).join("\n");
+    expect(joined).toContain("CREATE TABLE IF NOT EXISTS users");
+    expect(joined).toContain("CREATE TABLE IF NOT EXISTS sessions");
+    expect(joined).toContain("CREATE TABLE IF NOT EXISTS verifications");
+    expect(joined).toContain("CREATE TABLE IF NOT EXISTS roles");
+  });
+});
+
+describe("createTestApp", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns a real AuthInstance wired to the supplied D1", async () => {
+    const d1 = createMockD1();
+    const app = await createTestApp({
+      d1,
+      appUrl: "http://localhost:8787",
+      auth: { permissions, magicLink: { sendMagicLink: vi.fn() } },
+    });
+
+    expect(app.auth).toBeDefined();
+    expect(typeof app.auth.createContext).toBe("function");
+    expect(typeof app.auth.handler).toBe("function");
+    expect(app.d1).toBe(d1);
+    expect(app.appUrl).toBe("http://localhost:8787");
+    expect(app.capturedMagicLinks).toEqual([]);
+  });
+
+  it("defaults appUrl to http://localhost:8787", async () => {
+    const app = await createTestApp({
+      d1: createMockD1(),
+      auth: { permissions, magicLink: { sendMagicLink: vi.fn() } },
+    });
+    expect(app.appUrl).toBe("http://localhost:8787");
+  });
+
+  it("applies auth schema migrations by default", async () => {
+    const d1 = createMockD1();
+    const execSpy = vi.spyOn(d1, "exec");
+    await createTestApp({
+      d1,
+      auth: { permissions, magicLink: { sendMagicLink: vi.fn() } },
+    });
+    expect(execSpy).toHaveBeenCalledTimes(7);
+  });
+
+  it("skips migrations when applyMigrations is false", async () => {
+    const d1 = createMockD1();
+    const execSpy = vi.spyOn(d1, "exec");
+    await createTestApp({
+      d1,
+      auth: { permissions, magicLink: { sendMagicLink: vi.fn() } },
+      applyMigrations: false,
+    });
+    expect(execSpy).not.toHaveBeenCalled();
+  });
+
+  it("wraps the user's sendMagicLink to capture URLs", async () => {
+    const userSender = vi.fn();
+    const app = await createTestApp({
+      d1: createMockD1(),
+      auth: { permissions, magicLink: { sendMagicLink: userSender } },
+    });
+
+    // Invoke the wrapped sender the way Better Auth would.
+    const passedConfig = mockBetterAuth.mock.calls[0]![0] as {
+      plugins: Array<{ id: string; sendMagicLink: (p: { email: string; url: string }) => Promise<void> }>;
+    };
+    const magicLinkPlugin = passedConfig.plugins.find(
+      (p) => p.id === "magic-link",
+    );
+    expect(magicLinkPlugin).toBeDefined();
+
+    await magicLinkPlugin!.sendMagicLink({
+      email: "alice@test.com",
+      url: "http://localhost:8787/api/auth/magic-link/verify?token=XYZ123&callbackURL=%2F",
+    });
+
+    // User sender received the original params.
+    expect(userSender).toHaveBeenCalledTimes(1);
+    expect(userSender).toHaveBeenCalledWith({
+      email: "alice@test.com",
+      url: "http://localhost:8787/api/auth/magic-link/verify?token=XYZ123&callbackURL=%2F",
+    });
+
+    // Helper captured the link.
+    expect(app.capturedMagicLinks).toHaveLength(1);
+    expect(app.capturedMagicLinks[0]).toEqual({
+      email: "alice@test.com",
+      url: "http://localhost:8787/api/auth/magic-link/verify?token=XYZ123&callbackURL=%2F",
+      token: "XYZ123",
+    });
+  });
+
+  it("captures URLs even when the user did not provide a sendMagicLink", async () => {
+    const app = await createTestApp({
+      d1: createMockD1(),
+      auth: { permissions, magicLink: { sendMagicLink: vi.fn() } },
+    });
+
+    const passedConfig = mockBetterAuth.mock.calls[0]![0] as {
+      plugins: Array<{ id: string; sendMagicLink: (p: { email: string; url: string }) => Promise<void> }>;
+    };
+    const plugin = passedConfig.plugins.find((p) => p.id === "magic-link")!;
+    await plugin.sendMagicLink({
+      email: "bob@test.com",
+      url: "http://localhost:8787/api/auth/magic-link/verify?token=TKN",
+    });
+    expect(app.capturedMagicLinks).toHaveLength(1);
+    expect(app.capturedMagicLinks[0]!.token).toBe("TKN");
+  });
+
+  it("waitForMagicLink resolves synchronously when a link is already captured", async () => {
+    const app = await createTestApp({
+      d1: createMockD1(),
+      auth: { permissions, magicLink: { sendMagicLink: vi.fn() } },
+    });
+
+    const plugin = (mockBetterAuth.mock.calls[0]![0] as {
+      plugins: Array<{ id: string; sendMagicLink: (p: { email: string; url: string }) => Promise<void> }>;
+    }).plugins.find((p) => p.id === "magic-link")!;
+
+    await plugin.sendMagicLink({
+      email: "alice@test.com",
+      url: "http://localhost/api/auth/magic-link/verify?token=T1",
+    });
+
+    const link = await app.waitForMagicLink("alice@test.com");
+    expect(link.token).toBe("T1");
+  });
+
+  it("waitForMagicLink resolves when the link arrives later", async () => {
+    const app = await createTestApp({
+      d1: createMockD1(),
+      auth: { permissions, magicLink: { sendMagicLink: vi.fn() } },
+    });
+    const plugin = (mockBetterAuth.mock.calls[0]![0] as {
+      plugins: Array<{ id: string; sendMagicLink: (p: { email: string; url: string }) => Promise<void> }>;
+    }).plugins.find((p) => p.id === "magic-link")!;
+
+    const waiter = app.waitForMagicLink("late@test.com", { timeoutMs: 2_000 });
+    // Push the link after the wait has started.
+    setTimeout(() => {
+      void plugin.sendMagicLink({
+        email: "late@test.com",
+        url: "http://localhost/api/auth/magic-link/verify?token=LATE",
+      });
+    }, 10);
+
+    const link = await waiter;
+    expect(link.email).toBe("late@test.com");
+    expect(link.token).toBe("LATE");
+  });
+
+  it("waitForMagicLink times out when no link arrives", async () => {
+    const app = await createTestApp({
+      d1: createMockD1(),
+      auth: { permissions, magicLink: { sendMagicLink: vi.fn() } },
+    });
+    await expect(
+      app.waitForMagicLink("never@test.com", { timeoutMs: 50 }),
+    ).rejects.toThrow("timed out after 50ms");
+  });
+
+  it("waitForMagicLink ignores links for a different email when one is specified", async () => {
+    const app = await createTestApp({
+      d1: createMockD1(),
+      auth: { permissions, magicLink: { sendMagicLink: vi.fn() } },
+    });
+    const plugin = (mockBetterAuth.mock.calls[0]![0] as {
+      plugins: Array<{ id: string; sendMagicLink: (p: { email: string; url: string }) => Promise<void> }>;
+    }).plugins.find((p) => p.id === "magic-link")!;
+
+    const waiter = app.waitForMagicLink("target@test.com", { timeoutMs: 500 });
+    await plugin.sendMagicLink({
+      email: "other@test.com",
+      url: "http://localhost/api/auth/magic-link/verify?token=NO",
+    });
+    // The wrong-email link should NOT resolve the waiter.
+    await plugin.sendMagicLink({
+      email: "target@test.com",
+      url: "http://localhost/api/auth/magic-link/verify?token=YES",
+    });
+
+    const link = await waiter;
+    expect(link.token).toBe("YES");
+  });
+});
+
+describe("loginAs", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSession.mockResolvedValue(null);
+  });
+
+  it("drives the full send + verify flow and returns the real session row", async () => {
+    mockSignInMagicLink.mockImplementation(
+      async (opts: { body: { email: string; callbackURL?: string }; headers: HeadersInit }) => {
+        // Simulate what Better Auth's signInMagicLink does: invoke the
+        // configured sender with a real-looking URL. The plugin was
+        // handed to betterAuth() during createTestApp; pluck it and
+        // call it the way Better Auth would.
+        const config = mockBetterAuth.mock.calls[0]![0] as {
+          plugins: Array<{
+            id: string;
+            sendMagicLink: (p: { email: string; url: string; token: string }) => Promise<void>;
+          }>;
+        };
+        const plugin = config.plugins.find((p) => p.id === "magic-link")!;
+        const token = "real-token-xyz";
+        await plugin.sendMagicLink({
+          email: opts.body.email,
+          url: `http://localhost:8787/api/auth/magic-link/verify?token=${token}&callbackURL=%2F`,
+          token,
+        });
+      },
+    );
+
+    stubVerifyHandler();
+    const d1 = createMockD1();
+    seedSessionRow(d1, {
+      id: "session-row-1",
+      user_id: "user-1",
+      token: "token-abc",
+      expires_at: 1_900_000_000,
+      email: "alice@test.com",
+      name: "Alice",
+    });
+
+    const app = await createTestApp({
+      d1,
+      auth: { permissions, magicLink: { sendMagicLink: vi.fn() } },
+    });
+
+    const info = await loginAs(app, { email: "alice@test.com", name: "Alice" });
+
+    // Helper captured the link Better Auth generated.
+    expect(app.capturedMagicLinks).toHaveLength(1);
+    expect(app.capturedMagicLinks[0]!.token).toBe("real-token-xyz");
+
+    // handler() was invoked with the verify URL (with callbackURL stripped).
+    expect(mockHandler).toHaveBeenCalledTimes(1);
+    const verifyReq = mockHandler.mock.calls[0]![0] as Request;
+    expect(new URL(verifyReq.url).pathname).toBe("/api/auth/magic-link/verify");
+    expect(new URL(verifyReq.url).searchParams.get("token")).toBe("real-token-xyz");
+    expect(new URL(verifyReq.url).searchParams.get("callbackURL")).toBeNull();
+
+    // SessionInfo carries the canonical row from D1, not the response JSON.
+    expect(info.cookie).toBe("better-auth.session_token=token-abc");
+    expect(info.setCookieHeaders).toHaveLength(1);
+    expect(info.setCookieHeaders[0]).toContain("HttpOnly");
+    expect(info.user).toEqual({
+      id: "user-1",
+      email: "alice@test.com",
+      name: "Alice",
+    });
+    expect(info.session.id).toBe("session-row-1");
+    expect(info.session.token).toBe("token-abc");
+    expect(info.session.userId).toBe("user-1");
+    expect(info.session.expiresAt).toBeInstanceOf(Date);
+  });
+
+  it("assigns roles via the real setRole API path", async () => {
+    mockSignInMagicLink.mockImplementation(
+      async (opts: { body: { email: string }; headers: HeadersInit }) => {
+        const config = mockBetterAuth.mock.calls[0]![0] as {
+          plugins: Array<{ id: string; sendMagicLink: (p: { email: string; url: string; token: string }) => Promise<void> }>;
+        };
+        const plugin = config.plugins.find((p) => p.id === "magic-link")!;
+        await plugin.sendMagicLink({
+          email: opts.body.email,
+          url: "http://localhost:8787/api/auth/magic-link/verify?token=t1&callbackURL=%2F",
+          token: "t1",
+        });
+      },
+    );
+    stubVerifyHandler();
+
+    const d1 = createMockD1();
+    seedSessionRow(d1, {
+      id: "s-1",
+      user_id: "user-1",
+      token: "tok",
+      expires_at: 1_900_000_000,
+      email: "alice@test.com",
+      name: "Alice",
+    });
+    const app = await createTestApp({
+      d1,
+      auth: { permissions, magicLink: { sendMagicLink: vi.fn() } },
+    });
+    const setRoleSpy = vi.spyOn(app.auth, "setRole");
+
+    await loginAs(app, {
+      email: "alice@test.com",
+      roles: ["reader", "editor"],
+    });
+
+    expect(setRoleSpy).toHaveBeenCalledTimes(2);
+    expect(setRoleSpy).toHaveBeenNthCalledWith(1, "user-1", "reader");
+    expect(setRoleSpy).toHaveBeenNthCalledWith(2, "user-1", "editor");
+  });
+
+  it("throws when verification returns an error status", async () => {
+    mockSignInMagicLink.mockImplementation(
+      async (opts: { body: { email: string }; headers: HeadersInit }) => {
+        const config = mockBetterAuth.mock.calls[0]![0] as {
+          plugins: Array<{ id: string; sendMagicLink: (p: { email: string; url: string; token: string }) => Promise<void> }>;
+        };
+        const plugin = config.plugins.find((p) => p.id === "magic-link")!;
+        await plugin.sendMagicLink({
+          email: opts.body.email,
+          url: "http://localhost:8787/api/auth/magic-link/verify?token=bad",
+          token: "bad",
+        });
+      },
+    );
+    mockHandler.mockResolvedValue(
+      new Response("INVALID_TOKEN", { status: 400 }),
+    );
+
+    const app = await createTestApp({
+      d1: createMockD1(),
+      auth: { permissions, magicLink: { sendMagicLink: vi.fn() } },
+    });
+
+    await expect(
+      loginAs(app, { email: "alice@test.com" }),
+    ).rejects.toThrow("magic link verification failed (status 400)");
+  });
+
+  it("throws when the verify response carries no Set-Cookie header", async () => {
+    mockSignInMagicLink.mockImplementation(
+      async (opts: { body: { email: string }; headers: HeadersInit }) => {
+        const config = mockBetterAuth.mock.calls[0]![0] as {
+          plugins: Array<{ id: string; sendMagicLink: (p: { email: string; url: string; token: string }) => Promise<void> }>;
+        };
+        const plugin = config.plugins.find((p) => p.id === "magic-link")!;
+        await plugin.sendMagicLink({
+          email: opts.body.email,
+          url: "http://localhost:8787/api/auth/magic-link/verify?token=t",
+          token: "t",
+        });
+      },
+    );
+    mockHandler.mockResolvedValue(
+      new Response(JSON.stringify({ token: "t", user: { id: "u", email: "alice@test.com", name: "Alice" } }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+
+    const app = await createTestApp({
+      d1: createMockD1(),
+      auth: { permissions, magicLink: { sendMagicLink: vi.fn() } },
+    });
+
+    await expect(
+      loginAs(app, { email: "alice@test.com" }),
+    ).rejects.toThrow("verify response had no Set-Cookie header");
+  });
+
+  it("throws when D1 has no matching session row after verification", async () => {
+    mockSignInMagicLink.mockImplementation(
+      async (opts: { body: { email: string }; headers: HeadersInit }) => {
+        const config = mockBetterAuth.mock.calls[0]![0] as {
+          plugins: Array<{ id: string; sendMagicLink: (p: { email: string; url: string; token: string }) => Promise<void> }>;
+        };
+        const plugin = config.plugins.find((p) => p.id === "magic-link")!;
+        await plugin.sendMagicLink({
+          email: opts.body.email,
+          url: "http://localhost:8787/api/auth/magic-link/verify?token=t",
+          token: "t",
+        });
+      },
+    );
+    stubVerifyHandler();
+
+    const d1 = createMockD1(); // No session seeded -> first() returns null.
+    const app = await createTestApp({
+      d1,
+      auth: { permissions, magicLink: { sendMagicLink: vi.fn() } },
+    });
+    await expect(
+      loginAs(app, { email: "ghost@test.com" }),
+    ).rejects.toThrow("could not find a session row for ghost@test.com");
+  });
+});
+
+describe("createTestSession", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("calls auth.api.signInMagicLink directly and then verifies", async () => {
+    mockSignInMagicLink.mockImplementation(
+      async (opts: { body: { email: string; name?: string } }) => {
+        const config = mockBetterAuth.mock.calls[0]![0] as {
+          plugins: Array<{ id: string; sendMagicLink: (p: { email: string; url: string; token: string }) => Promise<void> }>;
+        };
+        const plugin = config.plugins.find((p) => p.id === "magic-link")!;
+        await plugin.sendMagicLink({
+          email: opts.body.email,
+          url: "http://localhost:8787/api/auth/magic-link/verify?token=direct",
+          token: "direct",
+        });
+      },
+    );
+    stubVerifyHandler(
+      ["better-auth.session_token=direct-token; HttpOnly"],
+      { token: "direct-token", user: { id: "u-2", email: "bob@test.com", name: "Bob" } },
+    );
+
+    const d1 = createMockD1();
+    seedSessionRow(d1, {
+      id: "s-bob",
+      user_id: "u-2",
+      token: "direct-token",
+      expires_at: 1_900_000_000,
+      email: "bob@test.com",
+      name: "Bob",
+    });
+
+    const app = await createTestApp({
+      d1,
+      auth: { permissions, magicLink: { sendMagicLink: vi.fn() } },
+    });
+
+    const info = await createTestSession(app, {
+      email: "bob@test.com",
+      name: "Bob",
+    });
+
+    expect(mockSignInMagicLink).toHaveBeenCalledTimes(1);
+    expect(mockSignInMagicLink).toHaveBeenCalledWith({
+      body: { email: "bob@test.com", name: "Bob", callbackURL: "/" },
+      headers: expect.any(Headers),
+    });
+    expect(info.cookie).toContain("better-auth.session_token=direct-token");
+    expect(info.user.id).toBe("u-2");
+    expect(info.session.id).toBe("s-bob");
+  });
+
+  it("omits the name field when none is provided", async () => {
+    mockSignInMagicLink.mockImplementation(
+      async (opts: { body: { email: string } }) => {
+        const config = mockBetterAuth.mock.calls[0]![0] as {
+          plugins: Array<{ id: string; sendMagicLink: (p: { email: string; url: string; token: string }) => Promise<void> }>;
+        };
+        const plugin = config.plugins.find((p) => p.id === "magic-link")!;
+        await plugin.sendMagicLink({
+          email: opts.body.email,
+          url: "http://localhost:8787/api/auth/magic-link/verify?token=noname",
+          token: "noname",
+        });
+      },
+    );
+    stubVerifyHandler();
+    const d1 = createMockD1();
+    seedSessionRow(d1, {
+      id: "s-1",
+      user_id: "user-1",
+      token: "token-abc",
+      expires_at: 1_900_000_000,
+      email: "alice@test.com",
+      name: "Alice",
+    });
+    const app = await createTestApp({
+      d1,
+      auth: { permissions, magicLink: { sendMagicLink: vi.fn() } },
+    });
+    await createTestSession(app, { email: "alice@test.com" });
+
+    expect(mockSignInMagicLink).toHaveBeenCalledWith({
+      body: { email: "alice@test.com", callbackURL: "/" },
+      headers: expect.any(Headers),
+    });
+  });
+});

--- a/packages/auth/src/test-helpers/index.ts
+++ b/packages/auth/src/test-helpers/index.ts
@@ -1,0 +1,694 @@
+/**
+ * @module test-helpers
+ *
+ * Real-workflow test helpers for `@cfast/auth`.
+ *
+ * These helpers exercise the **actual** Better Auth pipeline — they do not
+ * mock, stub, or hand-roll session inserts. A session created by `loginAs()`
+ * is byte-for-byte identical to one created by a user clicking a magic link
+ * in their inbox, because both go through the same `magicLinkVerify`
+ * endpoint and the same `internalAdapter.createSession` call.
+ *
+ * Use these helpers to drive end-to-end and integration tests that need a
+ * logged-in user without simulating the UI flow. The cookies they return
+ * can be attached to any `Request` and will be accepted by the same
+ * `auth.requireUser()` your loaders call in production.
+ *
+ * @example Drive a protected loader from a vitest test
+ * ```ts
+ * import { createTestApp, loginAs } from "@cfast/auth/test-helpers";
+ * import { permissions } from "../app/permissions";
+ * import { loader } from "../app/routes/dashboard";
+ *
+ * const app = await createTestApp({
+ *   d1: env.DB,
+ *   auth: { permissions },
+ * });
+ *
+ * const session = await loginAs(app, { email: "alice@test.com", name: "Alice" });
+ *
+ * const response = await loader({
+ *   request: new Request("http://localhost/dashboard", {
+ *     headers: { Cookie: session.cookie },
+ *   }),
+ * });
+ * ```
+ */
+import { createAuth } from "../create-auth";
+import type {
+  AuthConfig,
+  AuthInstance,
+  AuthEnvConfig,
+} from "../types";
+
+/**
+ * Details of a magic link captured by the helper's intercept.
+ *
+ * Captured every time the auth instance triggers a magic-link send during
+ * a test, regardless of whether `loginAs` or user code triggered it.
+ */
+export type CapturedMagicLink = {
+  /** The recipient address `signInMagicLink` was called with. */
+  email: string;
+  /** The full verification URL Better Auth generated, including the token query parameter. */
+  url: string;
+  /** The verification token, extracted from the URL for convenience. */
+  token: string;
+};
+
+/**
+ * A test app produced by {@link createTestApp}.
+ *
+ * Wraps a real {@link AuthInstance} and adds the test-only plumbing
+ * necessary to drive the magic-link flow programmatically. The `auth`
+ * field IS the production auth instance — no test doubles, no stubs.
+ */
+export type TestApp = {
+  /**
+   * The real, fully initialized {@link AuthInstance}, identical to the one
+   * `createAuth(config)(env)` would return in production. Pass this to your
+   * loaders, actions, or anything that consumes `AuthInstance`.
+   */
+  auth: AuthInstance;
+  /** The D1 binding the auth instance is wired to. */
+  d1: D1Database;
+  /** The base URL the auth instance uses (defaults to `http://localhost:8787`). */
+  appUrl: string;
+  /**
+   * Every magic link the auth instance has sent during this test, in
+   * insertion order. Includes links triggered by `loginAs()` and by any
+   * direct calls to `auth.sendMagicLink()` from your code under test.
+   */
+  capturedMagicLinks: CapturedMagicLink[];
+  /**
+   * Wait until a magic link has been captured (optionally for a specific
+   * email address) and return it. Resolves immediately if a matching link
+   * has already been captured before this call.
+   *
+   * @param email - If provided, only resolves on a link sent to this address.
+   * @param opts - Wait options. `timeoutMs` defaults to 5_000.
+   */
+  waitForMagicLink: (
+    email?: string,
+    opts?: { timeoutMs?: number },
+  ) => Promise<CapturedMagicLink>;
+  /**
+   * Tear down state held by this test app. Currently a no-op (the helper
+   * intentionally leaves the D1 contents alone so callers can inspect them
+   * after the test), but provided so future cleanup can be added without
+   * breaking the API.
+   */
+  cleanup: () => Promise<void>;
+};
+
+/**
+ * Configuration for {@link createTestApp}.
+ */
+export type CreateTestAppOptions = {
+  /**
+   * The D1 binding the auth instance should write to. The caller decides
+   * where the database lives — for `vitest-pool-workers` this is `env.DB`;
+   * for tests that bring their own miniflare, pass the D1 from the
+   * miniflare instance.
+   */
+  d1: D1Database;
+  /**
+   * Base URL the auth instance reports to Better Auth. Magic-link URLs
+   * Better Auth generates will use this as their origin.
+   *
+   * @default "http://localhost:8787"
+   */
+  appUrl?: string;
+  /**
+   * The same {@link AuthConfig} you would pass to `createAuth()` in
+   * production. The helper will inject its own `magicLink.sendMagicLink`
+   * if you do not provide one, and will also wrap any sender you do
+   * provide so the helper can still capture the URL.
+   */
+  auth: AuthConfig;
+  /**
+   * If true, runs the auth schema migrations against the supplied D1
+   * before returning the test app. Set this to `false` if you have
+   * already applied the migrations and want to skip the work.
+   *
+   * @default true
+   */
+  applyMigrations?: boolean;
+};
+
+/**
+ * A real session created by {@link loginAs} or {@link createTestSession}.
+ *
+ * Every field comes from the real `sessions` row that Better Auth wrote
+ * during verification — there is no synthetic data here.
+ */
+export type SessionInfo = {
+  /**
+   * A `Cookie` header value (e.g. `"better-auth.session_token=...; ..."`)
+   * ready to attach to a `Request` so subsequent calls into your loaders
+   * will see the user as authenticated.
+   */
+  cookie: string;
+  /**
+   * Every `Set-Cookie` header value Better Auth produced during the
+   * verification request. Useful when your tests need to inspect cookie
+   * attributes (HttpOnly, Secure, SameSite, etc.) directly.
+   */
+  setCookieHeaders: string[];
+  /** The user row Better Auth created or located during verification. */
+  user: {
+    id: string;
+    email: string;
+    name: string;
+  };
+  /** The session row Better Auth wrote to D1. */
+  session: {
+    id: string;
+    userId: string;
+    token: string;
+    expiresAt: Date;
+  };
+};
+
+/**
+ * Options for {@link loginAs}.
+ */
+export type LoginAsOptions = {
+  /** The email address to log in as. Created automatically if it does not exist. */
+  email: string;
+  /**
+   * Display name for the user. Used only if Better Auth needs to create
+   * the user during verification (the magic-link flow auto-creates users
+   * by default).
+   */
+  name?: string;
+  /**
+   * Roles to assign to the user immediately after the session is created.
+   * Each role is written via `auth.setRole()`, which uses the same code
+   * path your admin tooling does — no SQL inserts.
+   */
+  roles?: string[];
+};
+
+/**
+ * Options for {@link createTestSession}.
+ */
+export type CreateTestSessionOptions = {
+  /** The email address to create a session for. */
+  email: string;
+  /** Display name. Used if the user does not already exist. */
+  name?: string;
+  /** Roles to assign after session creation. See {@link LoginAsOptions.roles}. */
+  roles?: string[];
+};
+
+/**
+ * Applies the `@cfast/auth` schema migrations to a D1 database.
+ *
+ * Creates the `users`, `sessions`, `accounts`, `verifications`, `passkeys`,
+ * `roles`, and `impersonation_logs` tables if they do not already exist.
+ * Safe to call multiple times — every statement uses `IF NOT EXISTS`.
+ *
+ * Exposed so callers can pre-seed a shared D1 once in `beforeAll` and skip
+ * the per-test migration work via `applyMigrations: false`.
+ */
+export async function applyAuthSchema(d1: D1Database): Promise<void> {
+  // Statements are split because D1's exec() does not reliably handle
+  // multi-statement strings. Schema mirrors `packages/auth/src/schema.ts`.
+  const statements = [
+    "CREATE TABLE IF NOT EXISTS users (id TEXT PRIMARY KEY, email TEXT NOT NULL UNIQUE, name TEXT NOT NULL, image TEXT, email_verified INTEGER NOT NULL DEFAULT 0, created_at INTEGER NOT NULL DEFAULT (unixepoch()), updated_at INTEGER NOT NULL DEFAULT (unixepoch()))",
+    "CREATE TABLE IF NOT EXISTS sessions (id TEXT PRIMARY KEY, user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE, expires_at INTEGER NOT NULL, token TEXT NOT NULL UNIQUE, ip_address TEXT, user_agent TEXT, created_at INTEGER NOT NULL DEFAULT (unixepoch()), updated_at INTEGER NOT NULL DEFAULT (unixepoch()))",
+    "CREATE TABLE IF NOT EXISTS accounts (id TEXT PRIMARY KEY, user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE, account_id TEXT NOT NULL, provider_id TEXT NOT NULL, access_token TEXT, refresh_token TEXT, access_token_expires_at INTEGER, refresh_token_expires_at INTEGER, scope TEXT, id_token TEXT, password TEXT, created_at INTEGER NOT NULL DEFAULT (unixepoch()), updated_at INTEGER NOT NULL DEFAULT (unixepoch()))",
+    "CREATE TABLE IF NOT EXISTS verifications (id TEXT PRIMARY KEY, identifier TEXT NOT NULL, value TEXT NOT NULL, expires_at INTEGER NOT NULL, created_at INTEGER NOT NULL DEFAULT (unixepoch()), updated_at INTEGER NOT NULL DEFAULT (unixepoch()))",
+    "CREATE TABLE IF NOT EXISTS passkeys (id TEXT PRIMARY KEY, name TEXT, user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE, public_key TEXT NOT NULL, credential_id TEXT NOT NULL UNIQUE, counter INTEGER NOT NULL DEFAULT 0, device_type TEXT NOT NULL, backed_up INTEGER NOT NULL DEFAULT 0, transports TEXT, aaguid TEXT, created_at INTEGER)",
+    "CREATE TABLE IF NOT EXISTS roles (id TEXT PRIMARY KEY DEFAULT (lower(hex(randomblob(16)))), user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE, role TEXT NOT NULL, granted_by TEXT REFERENCES users(id), created_at INTEGER NOT NULL DEFAULT (unixepoch()))",
+    "CREATE TABLE IF NOT EXISTS impersonation_logs (id TEXT PRIMARY KEY, admin_id TEXT NOT NULL REFERENCES users(id), target_user_id TEXT NOT NULL REFERENCES users(id), started_at INTEGER NOT NULL DEFAULT (unixepoch()), ended_at INTEGER)",
+  ];
+  for (const sql of statements) {
+    await d1.exec(sql);
+  }
+}
+
+/**
+ * Spins up a real `@cfast/auth` instance against a D1 binding for use
+ * in tests.
+ *
+ * The returned {@link TestApp} contains the actual {@link AuthInstance}
+ * that `createAuth()` would have produced — no shims, no test doubles.
+ * The only thing the helper does on top is wrap the `magicLink.sendMagicLink`
+ * callback so the helper can capture every URL Better Auth generates,
+ * which is what {@link loginAs} uses to complete the verification step.
+ *
+ * If you pass your own `magicLink.sendMagicLink`, the helper will still
+ * call it (so your test can also assert on email content) and capture
+ * the URL on top.
+ *
+ * @example
+ * ```ts
+ * import { env } from "cloudflare:test";
+ * import { createTestApp, loginAs } from "@cfast/auth/test-helpers";
+ * import { permissions } from "../app/permissions";
+ *
+ * const app = await createTestApp({
+ *   d1: env.DB,
+ *   auth: { permissions, defaultRoles: ["user"] },
+ * });
+ *
+ * const { cookie, user } = await loginAs(app, { email: "alice@test.com" });
+ * ```
+ */
+export async function createTestApp(
+  opts: CreateTestAppOptions,
+): Promise<TestApp> {
+  const appUrl = opts.appUrl ?? "http://localhost:8787";
+  const captured: CapturedMagicLink[] = [];
+  const waiters: Array<{
+    email: string | undefined;
+    resolve: (link: CapturedMagicLink) => void;
+    reject: (err: Error) => void;
+  }> = [];
+
+  // Wrap the user's sendMagicLink (if any) so the helper always sees the
+  // URL Better Auth generated. This works whether the test triggers the
+  // send via `loginAs()` or via the code under test calling
+  // `auth.sendMagicLink()` directly.
+  const userSender = opts.auth.magicLink?.sendMagicLink;
+  const wrappedConfig: AuthConfig = {
+    ...opts.auth,
+    magicLink: {
+      sendMagicLink: async (params) => {
+        const link: CapturedMagicLink = {
+          email: params.email,
+          url: params.url,
+          token: extractTokenFromUrl(params.url),
+        };
+        captured.push(link);
+        // Notify any waiters whose criteria are now satisfied. Iterate
+        // backwards because we splice as we go.
+        for (let i = waiters.length - 1; i >= 0; i--) {
+          const waiter = waiters[i]!;
+          if (waiter.email === undefined || waiter.email === link.email) {
+            waiters.splice(i, 1);
+            waiter.resolve(link);
+          }
+        }
+        // Forward to the user's real sender so production-like sending
+        // (e.g., asserting that an email job was queued) still happens.
+        if (userSender) {
+          await userSender(params);
+        }
+      },
+    },
+  };
+
+  if (opts.applyMigrations !== false) {
+    await applyAuthSchema(opts.d1);
+  }
+
+  const initAuth = createAuth(wrappedConfig);
+  const env: AuthEnvConfig = { d1: opts.d1, appUrl };
+  const auth = initAuth(env);
+
+  return {
+    auth,
+    d1: opts.d1,
+    appUrl,
+    capturedMagicLinks: captured,
+    waitForMagicLink: (email, waitOpts) => {
+      const timeoutMs = waitOpts?.timeoutMs ?? 5_000;
+      // Already captured? Resolve synchronously.
+      const existing = captured.find(
+        (c) => email === undefined || c.email === email,
+      );
+      if (existing) return Promise.resolve(existing);
+      return new Promise<CapturedMagicLink>((resolve, reject) => {
+        const timer = setTimeout(() => {
+          const idx = waiters.findIndex((w) => w.resolve === wrappedResolve);
+          if (idx >= 0) waiters.splice(idx, 1);
+          reject(
+            new Error(
+              `[cfast/auth/test-helpers] waitForMagicLink timed out after ${timeoutMs}ms${
+                email ? ` waiting for ${email}` : ""
+              }`,
+            ),
+          );
+        }, timeoutMs);
+        const wrappedResolve = (link: CapturedMagicLink) => {
+          clearTimeout(timer);
+          resolve(link);
+        };
+        waiters.push({ email, resolve: wrappedResolve, reject });
+      });
+    },
+    cleanup: async () => {
+      // Reserved for future cleanup. Currently a no-op so callers can
+      // still inspect the D1 contents after the test finishes.
+    },
+  };
+}
+
+/**
+ * Logs in as the given user by completing the **real** magic-link flow
+ * end-to-end.
+ *
+ * Steps the helper performs (every one hits the real Better Auth pipeline):
+ *
+ * 1. Calls `app.auth.sendMagicLink({ email })`. This goes through the
+ *    same `signInMagicLink` endpoint your production code uses and writes
+ *    a row to the `verifications` table.
+ * 2. Captures the magic-link URL via the wrapped `sendMagicLink` callback.
+ * 3. Issues a real GET request to the magic-link verify endpoint via
+ *    `app.auth.handler(request)`. Better Auth verifies the token, creates
+ *    the user (if new), creates a session row, and returns a `Set-Cookie`
+ *    header.
+ * 4. Parses the response to extract the cookie and the session/user rows
+ *    Better Auth wrote.
+ * 5. Optionally assigns roles via the real `auth.setRole()` API.
+ *
+ * The returned {@link SessionInfo.cookie} can be attached to any `Request`
+ * and your loaders' `requireUser()` calls will return the same user that
+ * `loginAs` reports.
+ *
+ * @throws If the auth instance was not configured with a `magicLink`
+ *   plugin, if the magic link is never captured, or if the verify
+ *   endpoint returns an error.
+ *
+ * @example
+ * ```ts
+ * const session = await loginAs(app, {
+ *   email: "alice@test.com",
+ *   name: "Alice",
+ *   roles: ["editor"],
+ * });
+ *
+ * const response = await loader({
+ *   request: new Request("http://localhost/dashboard", {
+ *     headers: { Cookie: session.cookie },
+ *   }),
+ * });
+ * ```
+ */
+export async function loginAs(
+  app: TestApp,
+  options: LoginAsOptions,
+): Promise<SessionInfo> {
+  // Snapshot how many links were captured before triggering the send so
+  // we wait for the *next* one specifically (in case earlier tests left
+  // links in the buffer).
+  const beforeCount = app.capturedMagicLinks.length;
+
+  // Trigger the real send. This goes through `auth.api.signInMagicLink`
+  // which writes a verification row in D1 and calls our wrapped sender,
+  // which captures the URL.
+  await app.auth.sendMagicLink({
+    email: options.email,
+    callbackURL: "/",
+  });
+
+  // Wait for the wrapped sender to record the URL. In practice the
+  // capture is synchronous (sendMagicLink awaits the callback), so this
+  // resolves immediately, but we still poll to handle race conditions
+  // when the user code triggers extra sends in parallel.
+  const link = await waitForCapturedLink(app, options.email, beforeCount);
+
+  return verifyMagicLinkAndAssignRoles(app, link, options);
+}
+
+/**
+ * Lower-level companion to {@link loginAs} that creates a real session
+ * for a user without going through the public `auth.sendMagicLink()`
+ * surface.
+ *
+ * Functionally equivalent to `loginAs` from the consumer's perspective —
+ * the returned cookie is indistinguishable, the session row is
+ * indistinguishable, and the user row is indistinguishable. The
+ * difference is that `createTestSession`:
+ *
+ * - Calls `auth.api.signInMagicLink` directly so your test code does not
+ *   need to also wire up a `sendMagicLink` callback if it does not care
+ *   about email content.
+ * - Reads the freshly created verification token straight out of D1 and
+ *   issues the verify request, skipping the `waitForCapturedLink`
+ *   indirection.
+ *
+ * Use this when you want the cheapest possible way to mint a real
+ * session for a test user.
+ *
+ * @example
+ * ```ts
+ * const session = await createTestSession(app, {
+ *   email: "bob@test.com",
+ *   roles: ["admin"],
+ * });
+ * ```
+ */
+export async function createTestSession(
+  app: TestApp,
+  options: CreateTestSessionOptions,
+): Promise<SessionInfo> {
+  const beforeCount = app.capturedMagicLinks.length;
+
+  // Call the Better Auth endpoint directly via the escape-hatch `api`
+  // the `AuthInstance` exposes. `AuthInstance.api` is the whole Better
+  // Auth object, so the actual endpoint lives on `app.auth.api.api`.
+  // The wrapped sendMagicLink still fires (Better Auth always calls the
+  // configured sender), so we read the URL out of `app.capturedMagicLinks`
+  // afterwards. Going through the real endpoint guarantees the
+  // verification row was created via the real internalAdapter rather
+  // than a synthetic SQL insert.
+  type BetterAuthApi = {
+    api: {
+      signInMagicLink: (opts: {
+        body: { email: string; name?: string; callbackURL?: string };
+        headers: HeadersInit;
+      }) => Promise<unknown>;
+    };
+  };
+  const betterAuth = app.auth.api as unknown as BetterAuthApi;
+  await betterAuth.api.signInMagicLink({
+    body: {
+      email: options.email,
+      ...(options.name !== undefined ? { name: options.name } : {}),
+      callbackURL: "/",
+    },
+    headers: new Headers(),
+  });
+
+  const link = await waitForCapturedLink(app, options.email, beforeCount);
+  return verifyMagicLinkAndAssignRoles(app, link, options);
+}
+
+// ---------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------
+
+/**
+ * Extracts the verification token query parameter from a magic-link URL.
+ *
+ * @internal
+ */
+function extractTokenFromUrl(rawUrl: string): string {
+  try {
+    const url = new URL(rawUrl);
+    const token = url.searchParams.get("token");
+    if (!token) {
+      throw new Error(
+        `[cfast/auth/test-helpers] magic link URL did not contain a token: ${rawUrl}`,
+      );
+    }
+    return token;
+  } catch (err) {
+    if (err instanceof Error && err.message.includes("did not contain")) {
+      throw err;
+    }
+    throw new Error(
+      `[cfast/auth/test-helpers] failed to parse magic link URL: ${rawUrl}`,
+      { cause: err },
+    );
+  }
+}
+
+/**
+ * Waits for a captured link strictly newer than `beforeCount` and
+ * matching `email`. Throws if none arrives within the wait window.
+ *
+ * @internal
+ */
+async function waitForCapturedLink(
+  app: TestApp,
+  email: string,
+  beforeCount: number,
+): Promise<CapturedMagicLink> {
+  // First, check synchronously: in the typical sequential case the
+  // capture has already happened.
+  for (let i = beforeCount; i < app.capturedMagicLinks.length; i++) {
+    const link = app.capturedMagicLinks[i]!;
+    if (link.email === email) return link;
+  }
+  // Otherwise fall through to the helper's async waiter.
+  const link = await app.waitForMagicLink(email);
+  return link;
+}
+
+/**
+ * Issues the real verify request, parses the response, and assigns any
+ * requested roles. Shared by both {@link loginAs} and
+ * {@link createTestSession} so the contract they expose is identical.
+ *
+ * @internal
+ */
+async function verifyMagicLinkAndAssignRoles(
+  app: TestApp,
+  link: CapturedMagicLink,
+  options: { roles?: string[] },
+): Promise<SessionInfo> {
+  // Build a verify URL with NO callbackURL so the endpoint returns JSON
+  // (with the session token and user) instead of redirecting. This is
+  // strictly easier to parse than chasing a 302. The cookie is set
+  // either way; we read it from the JSON response's headers.
+  const verifyUrl = new URL(link.url);
+  verifyUrl.searchParams.delete("callbackURL");
+  verifyUrl.searchParams.delete("newUserCallbackURL");
+  verifyUrl.searchParams.delete("errorCallbackURL");
+
+  const verifyRequest = new Request(verifyUrl.toString(), { method: "GET" });
+  const response = await app.auth.handler(verifyRequest);
+
+  if (response.status >= 400) {
+    const body = await response.text();
+    throw new Error(
+      `[cfast/auth/test-helpers] magic link verification failed (status ${response.status}): ${body}`,
+    );
+  }
+
+  // Better Auth returns either a 200 with JSON or a 302 redirect (when
+  // callbackURL is set). We stripped callbackURL so we expect JSON, but
+  // handle the redirect case too in case the version of Better Auth
+  // ignores the missing callbackURL.
+  let parsed: { token?: string; user?: { id?: string; email?: string; name?: string } } = {};
+  if (response.headers.get("content-type")?.includes("application/json")) {
+    parsed = (await response.json()) as typeof parsed;
+  }
+
+  const setCookieHeaders = collectSetCookieHeaders(response.headers);
+  if (setCookieHeaders.length === 0) {
+    throw new Error(
+      "[cfast/auth/test-helpers] verify response had no Set-Cookie header — check that the magic-link plugin is configured correctly",
+    );
+  }
+
+  const cookie = setCookieHeaders
+    .map((h) => h.split(";", 1)[0])
+    .filter((c): c is string => Boolean(c))
+    .join("; ");
+
+  // Now read the actual session row Better Auth wrote so the returned
+  // SessionInfo carries the truth from the database, not whatever the
+  // verify endpoint happened to echo back.
+  const sessionRow = await loadLatestSession(app.d1, parsed.user?.email ?? link.email);
+  if (!sessionRow) {
+    throw new Error(
+      `[cfast/auth/test-helpers] could not find a session row for ${link.email} after verification`,
+    );
+  }
+
+  // Optionally assign roles using the REAL setRole API path so the
+  // resulting `roles` row is identical to one created by admin tooling.
+  if (options.roles && options.roles.length > 0) {
+    for (const role of options.roles) {
+      await app.auth.setRole(sessionRow.userId, role);
+    }
+  }
+
+  return {
+    cookie,
+    setCookieHeaders,
+    user: {
+      id: sessionRow.userId,
+      email: sessionRow.userEmail,
+      name: sessionRow.userName,
+    },
+    session: {
+      id: sessionRow.id,
+      userId: sessionRow.userId,
+      token: sessionRow.token,
+      expiresAt: sessionRow.expiresAt,
+    },
+  };
+}
+
+/**
+ * Collects every `Set-Cookie` header from a response. Workers' Headers
+ * implementation supports `getSetCookie()`, but we fall back to a manual
+ * walk for older runtimes.
+ *
+ * @internal
+ */
+function collectSetCookieHeaders(headers: Headers): string[] {
+  const headersWithGetSetCookie = headers as Headers & {
+    getSetCookie?: () => string[];
+  };
+  if (typeof headersWithGetSetCookie.getSetCookie === "function") {
+    return headersWithGetSetCookie.getSetCookie();
+  }
+  const all: string[] = [];
+  headers.forEach((value, key) => {
+    if (key.toLowerCase() === "set-cookie") all.push(value);
+  });
+  return all;
+}
+
+type SessionRow = {
+  id: string;
+  userId: string;
+  token: string;
+  expiresAt: Date;
+  userEmail: string;
+  userName: string;
+};
+
+/**
+ * Reads the most recent session for the given email out of D1. Used to
+ * surface the canonical session/user data in {@link SessionInfo}.
+ *
+ * @internal
+ */
+async function loadLatestSession(
+  d1: D1Database,
+  email: string,
+): Promise<SessionRow | null> {
+  const row = await d1
+    .prepare(
+      `SELECT s.id AS id, s.user_id AS user_id, s.token AS token, s.expires_at AS expires_at,
+              u.email AS email, u.name AS name
+       FROM sessions s
+       INNER JOIN users u ON u.id = s.user_id
+       WHERE u.email = ?
+       ORDER BY s.created_at DESC
+       LIMIT 1`,
+    )
+    .bind(email)
+    .first<{
+      id: string;
+      user_id: string;
+      token: string;
+      expires_at: number;
+      email: string;
+      name: string;
+    }>();
+  if (!row) return null;
+  return {
+    id: row.id,
+    userId: row.user_id,
+    token: row.token,
+    // Drizzle's sqlite `mode: "timestamp"` stores as unix seconds, so
+    // multiply to get the millis the `Date` constructor expects. If a
+    // future schema change moves to millis, the sniff below keeps the
+    // helper working without a migration guide.
+    expiresAt: new Date(
+      row.expires_at > 1e12 ? Number(row.expires_at) : Number(row.expires_at) * 1000,
+    ),
+    userEmail: row.email,
+    userName: row.name,
+  };
+}

--- a/tests/integration/auth-flow/test-helpers.test.ts
+++ b/tests/integration/auth-flow/test-helpers.test.ts
@@ -1,0 +1,513 @@
+/**
+ * Integration tests that prove `@cfast/auth/test-helpers` produces
+ * sessions indistinguishable from the real magic-link flow a user goes
+ * through in production.
+ *
+ * These tests run inside workerd (via @cloudflare/vitest-pool-workers)
+ * so the D1 binding, Better Auth runtime, and cookie handling are all
+ * real. A session row created by `loginAs()` is compared column-by-column
+ * to a session row created by driving the full Better Auth HTTP flow
+ * (sendMagicLink -> verify) by hand.
+ */
+import { env } from "cloudflare:test";
+import { describe, it, expect, beforeAll, beforeEach } from "vitest";
+import { createAuth } from "@cfast/auth";
+import * as authSchema from "@cfast/auth/schema";
+import {
+  createTestApp,
+  loginAs,
+  createTestSession,
+  applyAuthSchema,
+} from "@cfast/auth/test-helpers";
+import { definePermissions, grant } from "@cfast/permissions";
+
+const permissions = definePermissions({
+  roles: ["anonymous", "user", "editor", "admin"] as const,
+  grants: {
+    anonymous: [],
+    user: [grant("read", "all")],
+    editor: [grant("read", "all"), grant("update", "all")],
+    admin: [grant("manage", "all")],
+  },
+});
+
+const authConfig = {
+  permissions,
+  // Better Auth's drizzle adapter needs the schema passed explicitly
+  // when the workspace runs outside the app that owns the Drizzle
+  // setup. Without this, Better Auth tries to look up the `verifications`
+  // model and fails.
+  schema: authSchema,
+  anonymousRoles: ["anonymous"],
+  defaultRoles: ["user"],
+  magicLink: {
+    // The helper wraps this and captures URLs, but we still want to
+    // verify the sender is invoked (so tests can assert on email content
+    // if they wanted to).
+    sendMagicLink: async () => {
+      /* no-op: helper's wrapper is what captures the URL */
+    },
+  },
+};
+
+/**
+ * A protected "loader" that mirrors what a production React Router
+ * loader does: call `auth.requireUser(request)` and return the user.
+ * The integration tests drive this loader to prove the cookie the
+ * helper returns actually authenticates on the same code path that
+ * production uses.
+ */
+async function protectedLoader(
+  auth: ReturnType<ReturnType<typeof createAuth>>,
+  request: Request,
+) {
+  const ctx = await auth.requireUser(request);
+  return {
+    userId: ctx.user.id,
+    email: ctx.user.email,
+    name: ctx.user.name,
+    roles: ctx.user.roles,
+    grantCount: ctx.grants.length,
+  };
+}
+
+describe("test-helpers (integration)", () => {
+  beforeAll(async () => {
+    await applyAuthSchema(env.DB);
+  });
+
+  beforeEach(async () => {
+    await env.DB.batch([
+      env.DB.prepare("DELETE FROM impersonation_logs"),
+      env.DB.prepare("DELETE FROM roles"),
+      env.DB.prepare("DELETE FROM passkeys"),
+      env.DB.prepare("DELETE FROM verifications"),
+      env.DB.prepare("DELETE FROM accounts"),
+      env.DB.prepare("DELETE FROM sessions"),
+      env.DB.prepare("DELETE FROM users"),
+    ]);
+  });
+
+  describe("createTestApp", () => {
+    it("creates a real AuthInstance wired to env.DB", async () => {
+      const app = await createTestApp({
+        d1: env.DB,
+        appUrl: env.APP_URL,
+        auth: authConfig,
+        // Schema is already applied in beforeAll.
+        applyMigrations: false,
+      });
+
+      expect(app.auth).toBeDefined();
+      expect(typeof app.auth.requireUser).toBe("function");
+      expect(typeof app.auth.handler).toBe("function");
+
+      // A request against the real handler should succeed (Better Auth
+      // exposes /api/auth/ok as a health check).
+      const res = await app.auth.handler(
+        new Request(`${env.APP_URL}/api/auth/ok`),
+      );
+      expect(res.status).toBe(200);
+    });
+
+    it("applies schema migrations when asked", async () => {
+      // Drop the tables first so the migration has work to do.
+      await env.DB.exec("DROP TABLE IF EXISTS impersonation_logs");
+      await env.DB.exec("DROP TABLE IF EXISTS roles");
+      await env.DB.exec("DROP TABLE IF EXISTS passkeys");
+      await env.DB.exec("DROP TABLE IF EXISTS verifications");
+      await env.DB.exec("DROP TABLE IF EXISTS accounts");
+      await env.DB.exec("DROP TABLE IF EXISTS sessions");
+      await env.DB.exec("DROP TABLE IF EXISTS users");
+
+      await createTestApp({
+        d1: env.DB,
+        appUrl: env.APP_URL,
+        auth: authConfig,
+        // Explicitly true so the helper recreates everything.
+        applyMigrations: true,
+      });
+
+      // Querying each table should succeed; if the migration didn't run
+      // this would throw because the tables don't exist.
+      await env.DB.prepare("SELECT COUNT(*) FROM users").first();
+      await env.DB.prepare("SELECT COUNT(*) FROM sessions").first();
+      await env.DB.prepare("SELECT COUNT(*) FROM verifications").first();
+      await env.DB.prepare("SELECT COUNT(*) FROM roles").first();
+    });
+  });
+
+  describe("loginAs", () => {
+    it(
+      "produces a real session the production requireUser accepts",
+      { timeout: 30_000 },
+      async () => {
+        const app = await createTestApp({
+          d1: env.DB,
+          appUrl: env.APP_URL,
+          auth: authConfig,
+          applyMigrations: false,
+        });
+
+        const session = await loginAs(app, {
+          email: "alice@test.com",
+          name: "Alice",
+        });
+
+        // Cookie is populated.
+        expect(session.cookie).toBeTruthy();
+        expect(session.cookie).toContain("session");
+        expect(session.setCookieHeaders.length).toBeGreaterThan(0);
+
+        // Session row carries real IDs from the database.
+        expect(session.user.email).toBe("alice@test.com");
+        expect(session.user.id).toBeTruthy();
+        expect(session.session.id).toBeTruthy();
+        expect(session.session.userId).toBe(session.user.id);
+        expect(session.session.token).toBeTruthy();
+        expect(session.session.expiresAt).toBeInstanceOf(Date);
+        expect(session.session.expiresAt.getTime()).toBeGreaterThan(Date.now());
+
+        // CRITICAL: the cookie must authenticate on the REAL requireUser
+        // path. This proves the helper is indistinguishable from a user
+        // who clicked the magic link in their inbox.
+        const loaderResult = await protectedLoader(
+          app.auth,
+          new Request(`${env.APP_URL}/dashboard`, {
+            headers: { Cookie: session.cookie },
+          }),
+        );
+
+        expect(loaderResult.userId).toBe(session.user.id);
+        expect(loaderResult.email).toBe("alice@test.com");
+        expect(loaderResult.roles).toEqual(["user"]); // from defaultRoles
+        expect(loaderResult.grantCount).toBeGreaterThan(0);
+      },
+    );
+
+    it(
+      "assigns roles via the real setRole API path",
+      { timeout: 30_000 },
+      async () => {
+        const app = await createTestApp({
+          d1: env.DB,
+          appUrl: env.APP_URL,
+          auth: authConfig,
+          applyMigrations: false,
+        });
+
+        const session = await loginAs(app, {
+          email: "bob@test.com",
+          name: "Bob",
+          roles: ["editor"],
+        });
+
+        // The role should be persisted in the roles table exactly the
+        // way `auth.setRole()` would write it.
+        const rolesRow = await env.DB.prepare(
+          "SELECT role FROM roles WHERE user_id = ?",
+        )
+          .bind(session.user.id)
+          .all<{ role: string }>();
+        expect(rolesRow.results.map((r) => r.role)).toEqual(["editor"]);
+
+        // requireUser must see the editor role and its grants.
+        const loaderResult = await protectedLoader(
+          app.auth,
+          new Request(`${env.APP_URL}/admin`, {
+            headers: { Cookie: session.cookie },
+          }),
+        );
+        expect(loaderResult.roles).toEqual(["editor"]);
+      },
+    );
+
+    it(
+      "produces a session row indistinguishable from a hand-driven magic-link flow",
+      { timeout: 30_000 },
+      async () => {
+        // HAND-DRIVEN FLOW: simulate what a real user/client does by
+        // calling the public Better Auth API directly and following the
+        // verify link, capturing the URL manually.
+        let handDrivenUrl: string | null = null;
+        const initHandDriven = createAuth({
+          ...authConfig,
+          magicLink: {
+            sendMagicLink: async ({ url }) => {
+              handDrivenUrl = url;
+            },
+          },
+        });
+        const handDrivenAuth = initHandDriven({
+          d1: env.DB,
+          appUrl: env.APP_URL,
+        });
+
+        await handDrivenAuth.sendMagicLink({ email: "hand@test.com" });
+        expect(handDrivenUrl).not.toBeNull();
+
+        // Strip callbackURL so the verify endpoint returns JSON + sets a cookie.
+        const verifyUrl = new URL(handDrivenUrl!);
+        verifyUrl.searchParams.delete("callbackURL");
+        verifyUrl.searchParams.delete("newUserCallbackURL");
+        verifyUrl.searchParams.delete("errorCallbackURL");
+        const handDrivenResponse = await handDrivenAuth.handler(
+          new Request(verifyUrl.toString()),
+        );
+        expect(handDrivenResponse.status).toBeLessThan(400);
+        const handDrivenCookieHeaders =
+          typeof handDrivenResponse.headers.getSetCookie === "function"
+            ? handDrivenResponse.headers.getSetCookie()
+            : [];
+        expect(handDrivenCookieHeaders.length).toBeGreaterThan(0);
+
+        const handDrivenSessionRow = await env.DB.prepare(
+          `SELECT s.id, s.user_id, s.token, s.expires_at, s.created_at, s.updated_at,
+                  u.email, u.name, u.email_verified
+           FROM sessions s INNER JOIN users u ON u.id = s.user_id
+           WHERE u.email = ?
+           ORDER BY s.created_at DESC LIMIT 1`,
+        )
+          .bind("hand@test.com")
+          .first<{
+            id: string;
+            user_id: string;
+            token: string;
+            expires_at: number;
+            created_at: number;
+            updated_at: number;
+            email: string;
+            name: string;
+            email_verified: number;
+          }>();
+        expect(handDrivenSessionRow).not.toBeNull();
+
+        // HELPER-DRIVEN FLOW: now use loginAs() for a different user.
+        const app = await createTestApp({
+          d1: env.DB,
+          appUrl: env.APP_URL,
+          auth: authConfig,
+          applyMigrations: false,
+        });
+        const helperSession = await loginAs(app, {
+          email: "helper@test.com",
+          name: "Helper User",
+        });
+        const helperSessionRow = await env.DB.prepare(
+          `SELECT s.id, s.user_id, s.token, s.expires_at, s.created_at, s.updated_at,
+                  u.email, u.name, u.email_verified
+           FROM sessions s INNER JOIN users u ON u.id = s.user_id
+           WHERE u.email = ?
+           ORDER BY s.created_at DESC LIMIT 1`,
+        )
+          .bind("helper@test.com")
+          .first<{
+            id: string;
+            user_id: string;
+            token: string;
+            expires_at: number;
+            created_at: number;
+            updated_at: number;
+            email: string;
+            name: string;
+            email_verified: number;
+          }>();
+        expect(helperSessionRow).not.toBeNull();
+
+        // The rows must have the same SHAPE and the same field types.
+        // (IDs, tokens, timestamps differ between rows, but every field
+        // must be populated the same way.)
+        const handKeys = Object.keys(handDrivenSessionRow!).sort();
+        const helperKeys = Object.keys(helperSessionRow!).sort();
+        expect(helperKeys).toEqual(handKeys);
+
+        // Same field types.
+        for (const key of handKeys) {
+          expect(typeof helperSessionRow![key as keyof typeof helperSessionRow]).toBe(
+            typeof handDrivenSessionRow![key as keyof typeof handDrivenSessionRow],
+          );
+        }
+
+        // Both sessions must authenticate on the exact same requireUser code path.
+        const handDrivenCookie = handDrivenCookieHeaders
+          .map((h) => h.split(";", 1)[0])
+          .filter((c): c is string => Boolean(c))
+          .join("; ");
+
+        const handLoaderResult = await protectedLoader(
+          handDrivenAuth,
+          new Request(`${env.APP_URL}/dashboard`, {
+            headers: { Cookie: handDrivenCookie },
+          }),
+        );
+        const helperLoaderResult = await protectedLoader(
+          app.auth,
+          new Request(`${env.APP_URL}/dashboard`, {
+            headers: { Cookie: helperSession.cookie },
+          }),
+        );
+
+        // Both loaders returned consistent shapes and the same default role.
+        expect(Object.keys(handLoaderResult).sort()).toEqual(
+          Object.keys(helperLoaderResult).sort(),
+        );
+        expect(handLoaderResult.roles).toEqual(helperLoaderResult.roles);
+        expect(handLoaderResult.grantCount).toBe(helperLoaderResult.grantCount);
+        expect(handLoaderResult.email).toBe("hand@test.com");
+        expect(helperLoaderResult.email).toBe("helper@test.com");
+
+        // Both sessions live in the SAME sessions table alongside each
+        // other, with identical column populations. The helper's cookie
+        // is at no point a "test-mode" shortcut — it is a real session
+        // that `createContext()` cannot tell apart from the hand-driven
+        // one.
+        const allSessions = await env.DB.prepare(
+          "SELECT COUNT(*) AS n FROM sessions",
+        ).first<{ n: number }>();
+        expect(Number(allSessions!.n)).toBe(2);
+      },
+    );
+
+    it(
+      "captures magic link URLs for inspection during the test",
+      { timeout: 30_000 },
+      async () => {
+        const app = await createTestApp({
+          d1: env.DB,
+          appUrl: env.APP_URL,
+          auth: authConfig,
+          applyMigrations: false,
+        });
+        await loginAs(app, { email: "capture@test.com" });
+
+        expect(app.capturedMagicLinks).toHaveLength(1);
+        const captured = app.capturedMagicLinks[0]!;
+        expect(captured.email).toBe("capture@test.com");
+        expect(captured.url).toContain("/api/auth/magic-link/verify");
+        expect(captured.url).toContain("token=");
+        expect(captured.token).toBeTruthy();
+        expect(captured.token.length).toBeGreaterThan(10);
+      },
+    );
+  });
+
+  describe("createTestSession", () => {
+    it(
+      "creates a real session via auth.api.signInMagicLink",
+      { timeout: 30_000 },
+      async () => {
+        const app = await createTestApp({
+          d1: env.DB,
+          appUrl: env.APP_URL,
+          auth: authConfig,
+          applyMigrations: false,
+        });
+
+        const session = await createTestSession(app, {
+          email: "direct@test.com",
+          name: "Direct User",
+        });
+
+        expect(session.user.email).toBe("direct@test.com");
+        expect(session.cookie).toBeTruthy();
+        expect(session.session.expiresAt.getTime()).toBeGreaterThan(Date.now());
+
+        // The session cookie must authenticate on the real requireUser path.
+        const loaderResult = await protectedLoader(
+          app.auth,
+          new Request(`${env.APP_URL}/dashboard`, {
+            headers: { Cookie: session.cookie },
+          }),
+        );
+        expect(loaderResult.email).toBe("direct@test.com");
+        expect(loaderResult.userId).toBe(session.user.id);
+
+        // There must be exactly one session row for this user.
+        const rows = await env.DB.prepare(
+          "SELECT COUNT(*) AS n FROM sessions WHERE user_id = ?",
+        )
+          .bind(session.user.id)
+          .first<{ n: number }>();
+        expect(Number(rows!.n)).toBe(1);
+      },
+    );
+
+    it(
+      "assigns roles after the session is created",
+      { timeout: 30_000 },
+      async () => {
+        const app = await createTestApp({
+          d1: env.DB,
+          appUrl: env.APP_URL,
+          auth: authConfig,
+          applyMigrations: false,
+        });
+
+        const session = await createTestSession(app, {
+          email: "carol@test.com",
+          name: "Carol",
+          roles: ["admin"],
+        });
+
+        const rolesRow = await env.DB.prepare(
+          "SELECT role FROM roles WHERE user_id = ?",
+        )
+          .bind(session.user.id)
+          .all<{ role: string }>();
+        expect(rolesRow.results.map((r) => r.role)).toEqual(["admin"]);
+
+        const loaderResult = await protectedLoader(
+          app.auth,
+          new Request(`${env.APP_URL}/dashboard`, {
+            headers: { Cookie: session.cookie },
+          }),
+        );
+        expect(loaderResult.roles).toEqual(["admin"]);
+      },
+    );
+
+    it(
+      "produces a session indistinguishable from loginAs",
+      { timeout: 30_000 },
+      async () => {
+        const app = await createTestApp({
+          d1: env.DB,
+          appUrl: env.APP_URL,
+          auth: authConfig,
+          applyMigrations: false,
+        });
+
+        // Use loginAs for one user.
+        await loginAs(app, { email: "login@test.com", name: "Login User" });
+        // Use createTestSession for another.
+        await createTestSession(app, {
+          email: "direct@test.com",
+          name: "Direct User",
+        });
+
+        const rows = await env.DB.prepare(
+          `SELECT s.id, s.user_id, s.token, s.expires_at, u.email
+           FROM sessions s INNER JOIN users u ON u.id = s.user_id
+           ORDER BY u.email`,
+        ).all<{
+          id: string;
+          user_id: string;
+          token: string;
+          expires_at: number;
+          email: string;
+        }>();
+        expect(rows.results).toHaveLength(2);
+
+        // Same column set, same types.
+        const [direct, login] = rows.results;
+        for (const key of Object.keys(direct!)) {
+          expect(typeof login![key as keyof typeof login]).toBe(
+            typeof direct![key as keyof typeof direct],
+          );
+          expect(login![key as keyof typeof login]).toBeTruthy();
+          expect(direct![key as keyof typeof direct]).toBeTruthy();
+        }
+      },
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Adds the `@cfast/auth/test-helpers` subpath so tests can mint real sessions without mocking Better Auth or hand-writing SQL inserts.
- Every helper drives the **actual** auth pipeline — `loginAs()` triggers `auth.sendMagicLink()`, captures the URL the magic-link plugin generates, issues a real GET to `/api/auth/magic-link/verify` via `auth.handler()`, and parses the cookie + session row out of the response and D1.
- An integration test in `tests/integration/auth-flow/test-helpers.test.ts` proves indistinguishability by driving the magic-link flow by hand against a real D1, then driving it via the helper, and comparing the resulting `sessions` rows column-by-column. Both sessions then authenticate on the exact same `requireUser()` code path.

## API

```ts
import {
  createTestApp,
  loginAs,
  createTestSession,
  applyAuthSchema,
} from "@cfast/auth/test-helpers";

const app = await createTestApp({
  d1: env.DB,
  appUrl: env.APP_URL,
  auth: { permissions, schema: authSchema, defaultRoles: ["user"] },
});

// Full magic-link flow
const { cookie, user, session } = await loginAs(app, {
  email: "alice@test.com",
  name: "Alice",
  roles: ["editor"], // assigned via the real auth.setRole() API
});

// Lower-level: skip the email-send callback
await createTestSession(app, { email: "bob@test.com", roles: ["admin"] });

// Drive your production loaders with the cookie
const response = await loader({
  request: new Request("http://localhost/dashboard", {
    headers: { Cookie: cookie },
  }),
});
```

`createTestApp` also exposes `capturedMagicLinks` and `waitForMagicLink(email?)` so tests can assert on the URLs Better Auth generates.

## Test plan

- [x] `pnpm --filter @cfast/auth test` — 136 tests pass (118 existing + 18 new unit tests for the helpers)
- [x] `pnpm --filter @cfast/auth typecheck` — clean
- [x] `pnpm --filter @cfast/auth lint` — clean
- [x] `pnpm --filter @cfast/auth build` — produces `dist/test-helpers/index.{js,d.ts}`
- [x] `vitest run --project auth-flow` — 24 tests pass (5 files including the new `test-helpers.test.ts` with 9 integration tests)
- [x] Hand-driven flow + helper-driven flow produce sessions whose `sessions` rows have identical schema, identical field types, and authenticate on the same `requireUser()` code path

Closes #101