### PR TITLE
feat(create-cfast): ship local-first e2e smoke spec template

### DIFF
--- a/packages/create-cfast/src/__tests__/smoke-spec-extraction.test.ts
+++ b/packages/create-cfast/src/__tests__/smoke-spec-extraction.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { scaffold } from "../scaffold";
+import { resolveConfig } from "../config";
+import type { Config } from "../types";
+
+/**
+ * Mirrors the route-discovery logic in
+ * `templates/base/e2e/smoke.spec.ts::discoverRoutes()`.
+ *
+ * The smoke spec runs inside the scaffolded app at runtime where vitest is not
+ * available, so we duplicate the function here and assert the regex behaviour
+ * end-to-end. If you change the smoke spec's discovery, change this in lockstep.
+ */
+function extractRoutes(routesFile: string): string[] {
+  const routes: string[] = [];
+  if (/index\(/.test(routesFile)) routes.push("/");
+  const matches = routesFile.matchAll(/route\(\s*["']([^"']+)["']/g);
+  for (const m of matches) {
+    const p = m[1];
+    if (p.includes(":") || p.includes("*")) continue;
+    routes.push(`/${p}`);
+  }
+  return routes;
+}
+
+describe("route extraction", () => {
+  it("finds index", () => {
+    expect(extractRoutes(`index("routes/_index.tsx")`)).toEqual(["/"]);
+  });
+
+  it("finds simple routes", () => {
+    expect(extractRoutes(`route("login", "routes/login.tsx")`)).toEqual(["/login"]);
+  });
+
+  it("skips dynamic routes", () => {
+    expect(extractRoutes(`route("foo/:id", "routes/foo.$id.tsx")`)).toEqual([]);
+  });
+
+  it("skips wildcards", () => {
+    expect(extractRoutes(`route("api/*", "routes/api.$.tsx")`)).toEqual([]);
+  });
+
+  it("finds index plus multiple static routes and skips dynamic ones", () => {
+    const file = `
+      import { type RouteConfig, index, route } from "@react-router/dev/routes";
+
+      export default [
+        index("routes/_index.tsx"),
+        route("login", "routes/login.tsx"),
+        route("admin", "routes/admin.tsx"),
+        route("api/auth/*", "routes/auth.$.tsx"),
+        route("posts/:id", "routes/posts.$id.tsx"),
+        route("about", "routes/about.tsx"),
+      ] satisfies RouteConfig;
+    `;
+    expect(extractRoutes(file)).toEqual(["/", "/login", "/admin", "/about"]);
+  });
+
+  it("handles single quotes", () => {
+    expect(extractRoutes(`route('settings', 'routes/settings.tsx')`)).toEqual([
+      "/settings",
+    ]);
+  });
+
+  it("returns empty when no routes are present", () => {
+    expect(extractRoutes(`export default [] satisfies RouteConfig;`)).toEqual([]);
+  });
+});
+
+describe("scaffold ships e2e infrastructure", () => {
+  function scaffoldFixture(label: string, partial: Partial<Config["features"]> = {}): string {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), `cfast-e2e-template-${label}-`));
+    const targetDir = path.join(tmp, "demo-app");
+    const config = resolveConfig({
+      projectName: "demo-app",
+      targetDir,
+      features: {
+        auth: false,
+        db: false,
+        storage: false,
+        email: false,
+        ui: false,
+        admin: false,
+        ...partial,
+      },
+      uiLibrary: null,
+    });
+    scaffold(config);
+    return targetDir;
+  }
+
+  it("ships e2e/playwright.config.ts with localhost baseURL and webServer", () => {
+    const targetDir = scaffoldFixture("playwright");
+    const pw = fs.readFileSync(
+      path.join(targetDir, "e2e", "playwright.config.ts"),
+      "utf-8",
+    );
+    expect(pw).toContain("http://localhost:${PORT}");
+    expect(pw).toContain("webServer");
+    expect(pw).toContain("reuseExistingServer: !process.env.CI");
+    expect(pw).toContain("E2E_BASE_URL");
+    fs.rmSync(path.dirname(targetDir), { recursive: true, force: true });
+  });
+
+  it("ships e2e/smoke.spec.ts that auto-discovers routes", () => {
+    const targetDir = scaffoldFixture("smoke");
+    const smoke = fs.readFileSync(path.join(targetDir, "e2e", "smoke.spec.ts"), "utf-8");
+    expect(smoke).toContain("discoverRoutes");
+    expect(smoke).toContain('readFileSync(join(__dirname, "..", "app", "routes.ts"');
+    expect(smoke).toContain("Get started by editing");
+    expect(smoke).toContain("/Users/");
+    expect(smoke).toContain("/home/");
+    fs.rmSync(path.dirname(targetDir), { recursive: true, force: true });
+  });
+
+  it("ships e2e/helpers.ts with gotoOk", () => {
+    const targetDir = scaffoldFixture("helpers");
+    const helpers = fs.readFileSync(path.join(targetDir, "e2e", "helpers.ts"), "utf-8");
+    expect(helpers).toContain("export async function gotoOk");
+    expect(helpers).toContain("status !== 401 && status !== 403");
+    fs.rmSync(path.dirname(targetDir), { recursive: true, force: true });
+  });
+
+  it("ships test:e2e script and @playwright/test devDep in package.json", () => {
+    const targetDir = scaffoldFixture("pkg");
+    const pkg = JSON.parse(
+      fs.readFileSync(path.join(targetDir, "package.json"), "utf-8"),
+    );
+    expect(pkg.scripts["test:e2e"]).toBe(
+      "playwright test --config=e2e/playwright.config.ts",
+    );
+    expect(pkg.devDependencies["@playwright/test"]).toBeTruthy();
+    fs.rmSync(path.dirname(targetDir), { recursive: true, force: true });
+  });
+
+  it("documents the local-first e2e contract in CLAUDE.md", () => {
+    const targetDir = scaffoldFixture("docs");
+    const claudeMd = fs.readFileSync(path.join(targetDir, "CLAUDE.md"), "utf-8");
+    expect(claudeMd).toContain("E2E Tests Are Local-First");
+    expect(claudeMd).toContain("baseURL` MUST default to `http://localhost:5173`");
+    expect(claudeMd).toContain("webServer");
+    expect(claudeMd).toContain("smoke.spec.ts");
+    expect(claudeMd).toContain("gotoOk");
+    fs.rmSync(path.dirname(targetDir), { recursive: true, force: true });
+  });
+});

--- a/packages/create-cfast/templates/base/CLAUDE.md
+++ b/packages/create-cfast/templates/base/CLAUDE.md
@@ -97,6 +97,14 @@ Use field overrides when calling the form generator:
 { fields: { title: { label: "Item Name", placeholder: "Enter name..." } } }
 ```
 
+## E2E Tests Are Local-First
+
+- `playwright.config.ts` `baseURL` MUST default to `http://localhost:5173`. Pointing the default at a deployed URL is forbidden — it makes passes meaningless on a fresh checkout.
+- `playwright.config.ts` MUST include a `webServer` block with `reuseExistingServer: !process.env.CI`.
+- Every new route MUST be implicitly covered by `e2e/smoke.spec.ts` (which auto-discovers routes from `app/routes.ts`). Do not delete this spec.
+- For feature specs, use `gotoOk(page, path)` from `e2e/helpers.ts` instead of raw `page.goto()` so 4xx surfaces as a routing failure, not a selector timeout.
+- `test.skip(...)` is only acceptable for tests requiring external services (real email, real OAuth). It is NOT a substitute for a fixture; authenticated tests should use the test helpers from `@cfast/auth/test-helpers`.
+
 ## Anti-Patterns — Do NOT Do These
 
 | Instead of... | Do this |

--- a/packages/create-cfast/templates/base/e2e/helpers.ts
+++ b/packages/create-cfast/templates/base/e2e/helpers.ts
@@ -1,0 +1,16 @@
+import { expect, type Page, type Response } from "@playwright/test";
+
+/**
+ * Like page.goto() but throws if the response is a 4xx/5xx (other than 401/403 which mean
+ * "the route exists, you're not authorized"). Use this in feature specs to fail loudly on
+ * routing regressions instead of getting a confusing locator timeout deeper in the test.
+ */
+export async function gotoOk(page: Page, path: string): Promise<Response> {
+  const response = await page.goto(path);
+  expect(response, `no response for ${path}`).not.toBeNull();
+  const status = response!.status();
+  if (status >= 400 && status !== 401 && status !== 403) {
+    throw new Error(`gotoOk("${path}") got status ${status}`);
+  }
+  return response!;
+}

--- a/packages/create-cfast/templates/base/e2e/playwright.config.ts
+++ b/packages/create-cfast/templates/base/e2e/playwright.config.ts
@@ -1,0 +1,28 @@
+import { defineConfig } from "@playwright/test";
+
+const PORT = 5173;
+const LOCAL_BASE_URL = `http://localhost:${PORT}`;
+const baseURL = process.env.E2E_BASE_URL ?? LOCAL_BASE_URL;
+const isLocal = baseURL === LOCAL_BASE_URL;
+
+export default defineConfig({
+  testDir: ".",
+  timeout: 30_000,
+  use: {
+    baseURL,
+    trace: "on-first-retry",
+    screenshot: "only-on-failure",
+  },
+  // Auto-start the dev server only when running locally
+  webServer: isLocal
+    ? {
+        command: "pnpm dev",
+        url: LOCAL_BASE_URL,
+        reuseExistingServer: !process.env.CI,
+        timeout: 120_000,
+        stdout: "pipe",
+        stderr: "pipe",
+      }
+    : undefined,
+  projects: [{ name: "chromium", use: { browserName: "chromium" } }],
+});

--- a/packages/create-cfast/templates/base/e2e/smoke.spec.ts
+++ b/packages/create-cfast/templates/base/e2e/smoke.spec.ts
@@ -1,0 +1,55 @@
+import { test, expect } from "@playwright/test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * Auto-discovers routes from app/routes.ts and verifies each one:
+ *  - returns HTTP < 400 (or 401/403 for protected routes)
+ *  - body does NOT contain placeholder strings ("Get started by editing", absolute fs paths)
+ *
+ * If you add a route to app/routes.ts and `pnpm test:e2e` is green,
+ * the route is reachable. If it fails, your routes.ts is wrong or
+ * the route file has a runtime error.
+ */
+
+function discoverRoutes(): string[] {
+  const file = readFileSync(join(__dirname, "..", "app", "routes.ts"), "utf-8");
+  // Match index("routes/_index.tsx") -> "/"
+  // Match route("foo", "routes/foo.tsx") -> "/foo"
+  // Skip dynamic routes (":id", "*") that we can't resolve for a smoke test
+  const routes: string[] = [];
+  if (/index\(/.test(file)) routes.push("/");
+  const routeMatches = file.matchAll(/route\(\s*["']([^"']+)["']/g);
+  for (const m of routeMatches) {
+    const path = m[1];
+    if (path.includes(":") || path.includes("*")) continue;
+    routes.push(`/${path}`);
+  }
+  return routes;
+}
+
+const ROUTES = discoverRoutes();
+
+// Status codes that are acceptable for "the route exists"
+const OK = (code: number) => code < 400 || code === 401 || code === 403;
+
+for (const path of ROUTES) {
+  test(`route ${path} is registered and responds`, async ({ page }) => {
+    const response = await page.goto(path);
+    expect(response, `no response for ${path}`).not.toBeNull();
+    const status = response!.status();
+    expect(OK(status), `${path} returned ${status}`).toBe(true);
+
+    // Catch placeholder pages even if status is 200
+    const body = await page.content();
+    expect(body, `${path} contains scaffold placeholder`).not.toContain(
+      "Get started by editing",
+    );
+    expect(body, `${path} leaks absolute filesystem path`).not.toContain("/Users/");
+    expect(body, `${path} leaks absolute filesystem path`).not.toContain("/home/");
+  });
+}
+
+test(`smoke: discovered ${ROUTES.length} routes`, async () => {
+  expect(ROUTES.length, "no routes discovered from app/routes.ts").toBeGreaterThan(0);
+});

--- a/packages/create-cfast/templates/base/package.json
+++ b/packages/create-cfast/templates/base/package.json
@@ -7,6 +7,7 @@
     "dev": "react-router dev",
     "preview": "pnpm run build && vite preview",
     "typecheck": "react-router typegen && tsc -b",
+    "test:e2e": "playwright test --config=e2e/playwright.config.ts",
     "deploy:staging": "pnpm run build && wrangler deploy --env staging",
     "deploy:production": "pnpm run build && wrangler deploy --env production"
   },
@@ -22,6 +23,7 @@
   "devDependencies": {
     "@cloudflare/vite-plugin": "^1.27.0",
     "@cloudflare/workers-types": "^4.20260310.1",
+    "@playwright/test": "^1.52.0",
     "@react-router/dev": "^7.13.1",
     "@types/node": "^22",
     "@types/react": "^19.2.7",


### PR DESCRIPTION
## Summary

- Adds `e2e/playwright.config.ts`, `e2e/smoke.spec.ts`, and `e2e/helpers.ts` to `packages/create-cfast/templates/base` so every scaffolded project gets a working local-first e2e test rig out of the box.
- Wires `test:e2e` script and `@playwright/test` devDep into the base `package.json`.
- Documents the local-first contract (localhost baseURL, webServer, smoke spec, gotoOk) in the scaffolded `CLAUDE.md`.
- Adds 12 unit tests covering the smoke spec's route-extraction regex and verifying the scaffold actually ships the new files.

## Why

All four cfast-playground demo apps shipped apps where most routes 404, and no e2e test caught it. Investigation surfaced five compounding defects in the playwright setup every swarm inherited:

1. `playwright.config.ts` `baseURL` defaulted to a deployed prod URL, not localhost — a fresh checkout tested the old deployed app.
2. No `webServer` block — `pnpm test:e2e` never started `pnpm dev`.
3. Tests were gated behind unset env vars and silently skipped.
4. Permissive selectors happily matched error/404 pages.
5. `page.goto()` return values were discarded, so HTTP 404 was indistinguishable from HTTP 200 in the specs.

The new `smoke.spec.ts` reads `app/routes.ts`, enumerates every static route, and asserts each one returns `<400` (or `401/403` for protected routes) and does not contain scaffold-placeholder strings. The `gotoOk()` helper makes 4xx loud for feature specs. With this template a swarm physically cannot scaffold a project that passes `pnpm test:e2e` while its routes 404.

## Test plan

- [x] `pnpm --filter create-cfast test` — 59 tests pass (includes 12 new smoke-spec-extraction + scaffold-wiring tests, and the 8 full scaffold-build tests that actually build a scaffolded project end-to-end).
- [x] `pnpm --filter create-cfast typecheck` — clean.
- [x] `pnpm --filter create-cfast lint` — clean.
- [x] `pnpm --filter create-cfast build` — clean.
- [x] `pnpm typecheck` monorepo-wide — 37/37 tasks pass.
- [x] `pnpm build` monorepo-wide — 25/25 tasks pass.
- [x] `pnpm test:unit` monorepo-wide — 28/28 tasks pass.
- [x] Applied the same files to the 4 existing demo apps (`cfast-tracker`, `cfast-wiki`, `cfast-meals`, `cfast-store`) and confirmed the smoke spec fails loudly on every route currently orphaned — see the issue thread for the per-app orphan count.

Squash-merge and enable auto-merge.