### PR TITLE
fix(create-cfast): ESM-safe __dirname in scaffolded e2e smoke spec

### DIFF
--- a/packages/create-cfast/src/__tests__/smoke-spec-extraction.test.ts
+++ b/packages/create-cfast/src/__tests__/smoke-spec-extraction.test.ts
@@ -109,7 +109,9 @@ describe("scaffold ships e2e infrastructure", () => {
     const targetDir = scaffoldFixture("smoke");
     const smoke = fs.readFileSync(path.join(targetDir, "e2e", "smoke.spec.ts"), "utf-8");
     expect(smoke).toContain("discoverRoutes");
-    expect(smoke).toContain('readFileSync(join(__dirname, "..", "app", "routes.ts"');
+    // ESM-safe __dirname resolution (scaffolded projects are `"type": "module"`)
+    expect(smoke).toContain("fileURLToPath(import.meta.url)");
+    expect(smoke).toContain('join(HERE, "..", "app", "routes.ts"');
     expect(smoke).toContain("Get started by editing");
     expect(smoke).toContain("/Users/");
     expect(smoke).toContain("/home/");

--- a/packages/create-cfast/templates/base/e2e/smoke.spec.ts
+++ b/packages/create-cfast/templates/base/e2e/smoke.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect } from "@playwright/test";
 import { readFileSync } from "node:fs";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 
 /**
  * Auto-discovers routes from app/routes.ts and verifies each one:
@@ -12,8 +13,11 @@ import { join } from "node:path";
  * the route file has a runtime error.
  */
 
+// ESM-safe __dirname (scaffolded projects are `"type": "module"`).
+const HERE = dirname(fileURLToPath(import.meta.url));
+
 function discoverRoutes(): string[] {
-  const file = readFileSync(join(__dirname, "..", "app", "routes.ts"), "utf-8");
+  const file = readFileSync(join(HERE, "..", "app", "routes.ts"), "utf-8");
   // Match index("routes/_index.tsx") -> "/"
   // Match route("foo", "routes/foo.tsx") -> "/foo"
   // Skip dynamic routes (":id", "*") that we can't resolve for a smoke test


### PR DESCRIPTION
## Summary

- Scaffolded projects are `"type": "module"`, so the template `e2e/smoke.spec.ts` crashes before any test runs: `ReferenceError: __dirname is not defined in ES module scope`.
- Switches to the ESM-safe pattern `const HERE = dirname(fileURLToPath(import.meta.url));`.
- Updates the unit test to assert the ESM-safe pattern is shipped.

Follow-up to #167, which introduced the template. Caught immediately when rolling the template out to the four cfast-playground demo apps.

## Test plan

- [x] `pnpm --filter create-cfast test` — 59/59 pass, including 12 smoke-spec-extraction tests and all 8 scaffold-build tests.
- [x] `pnpm --filter create-cfast typecheck` / `lint` / `build` — clean.
- [x] Applied to all 4 cfast-playground demo apps and confirmed the smoke spec runs correctly and fails loudly on the `/` scaffold placeholder (and on cfast-wiki's orphaned `/search` route).

Squash-merge and enable auto-merge.