### PR TITLE
feat(auth): add createAuthHelpers to eliminate per-app boilerplate

### DIFF
--- a/packages/auth/llms.txt
+++ b/packages/auth/llms.txt
@@ -114,6 +114,50 @@ const auth = createAdminAuth(() =>
 const admin = createAdmin({ auth, db: createDbForAdmin, schema });
 ```
 
+### Auth helpers (`@cfast/auth/helpers`)
+
+```typescript
+import { createAuthHelpers } from "@cfast/auth/helpers";
+
+function createAuthHelpers<TUser extends AuthUser = AuthUser>(options: {
+  getAuth: () => AuthInstance;
+  enrichUser?: (user: AuthUser) => Promise<TUser> | TUser;
+}): AuthHelpers<TUser>
+```
+
+Replaces ~35 lines of identical `auth.helpers.server.ts` boilerplate that every cfast app copy-pastes. Returns `{ getAuthContext, requireAuthContext, getUser, requireUser }`.
+
+The optional `enrichUser` hook lets apps extend the base `AuthUser` with custom fields (e.g., `vendorId` in a marketplace). When provided, every helper passes the user through `enrichUser` before returning.
+
+```typescript
+// Basic usage (tracker, wiki, meals)
+import { createAuthHelpers } from "@cfast/auth/helpers";
+import { initAuth } from "./auth.setup.server";
+import { env } from "./env";
+
+export const { getAuthContext, requireAuthContext, getUser, requireUser } =
+  createAuthHelpers({
+    getAuth: () => initAuth({ d1: env.get().DB, appUrl: env.get().APP_URL }),
+  });
+```
+
+```typescript
+// With enrichUser (store app)
+export const { getAuthContext, requireAuthContext, getUser, requireUser } =
+  createAuthHelpers<StoreUser>({
+    getAuth: () => initAuth({ d1: env.get().DB, appUrl: env.get().APP_URL }),
+    enrichUser: async (user) => {
+      const vendor = await lookupVendor(user.id);
+      return { ...user, vendorId: vendor?.id ?? null };
+    },
+  });
+```
+
+Also re-exported from `@cfast/auth` main entry for convenience:
+```typescript
+import { createAuthHelpers } from "@cfast/auth";
+```
+
 ### Client exports (`@cfast/auth/client`)
 
 ```typescript

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -27,6 +27,10 @@
       "import": "./dist/client.js",
       "types": "./dist/client.d.ts"
     },
+    "./helpers": {
+      "import": "./dist/helpers.js",
+      "types": "./dist/helpers.d.ts"
+    },
     "./plugin": {
       "import": "./dist/plugin.js",
       "types": "./dist/plugin.d.ts"
@@ -53,8 +57,8 @@
     "access": "public"
   },
   "scripts": {
-    "build": "tsup src/index.ts src/client.ts src/plugin.ts src/schema.ts src/test-helpers/index.ts src/test-helpers/passkey.ts --format esm --dts",
-    "dev": "tsup src/index.ts src/client.ts src/plugin.ts src/schema.ts src/test-helpers/index.ts src/test-helpers/passkey.ts --format esm --dts --watch",
+    "build": "tsup src/index.ts src/client.ts src/helpers.ts src/plugin.ts src/schema.ts src/test-helpers/index.ts src/test-helpers/passkey.ts --format esm --dts",
+    "dev": "tsup src/index.ts src/client.ts src/helpers.ts src/plugin.ts src/schema.ts src/test-helpers/index.ts src/test-helpers/passkey.ts --format esm --dts --watch",
     "test": "vitest run",
     "typecheck": "tsc --noEmit",
     "lint": "eslint src/"

--- a/packages/auth/src/__tests__/helpers.test.ts
+++ b/packages/auth/src/__tests__/helpers.test.ts
@@ -1,0 +1,250 @@
+import { describe, it, expect, vi } from "vitest";
+import { createAuthHelpers } from "../helpers";
+import type { AuthInstance, AuthUser } from "../types";
+
+function mockAuthInstance(overrides?: Partial<AuthInstance>): AuthInstance {
+  const baseUser: AuthUser = {
+    id: "u1",
+    email: "alice@example.com",
+    name: "Alice",
+    avatarUrl: null,
+    roles: ["admin"],
+  };
+
+  const getRoles = vi.fn().mockResolvedValue(["admin"]);
+  const setRole = vi.fn().mockResolvedValue(undefined);
+  const setRoles = vi.fn().mockResolvedValue(undefined);
+  const removeRole = vi.fn().mockResolvedValue(undefined);
+
+  return {
+    createContext: vi.fn().mockResolvedValue({
+      user: baseUser,
+      grants: [{ action: "manage" as const, subject: "all" as const }],
+    }),
+    requireUser: vi.fn().mockResolvedValue({
+      user: baseUser,
+      grants: [{ action: "manage" as const, subject: "all" as const }],
+    }),
+    roles: { get: getRoles, set: setRole, setAll: setRoles, remove: removeRole },
+    getRoles,
+    setRole,
+    setRoles,
+    removeRole,
+    impersonate: vi.fn().mockResolvedValue(undefined),
+    stopImpersonating: vi.fn().mockResolvedValue(undefined),
+    handler: vi.fn(),
+    sendMagicLink: vi.fn(),
+    api: {},
+    ...overrides,
+  };
+}
+
+describe("createAuthHelpers", () => {
+  it("returns all four helper functions", () => {
+    const auth = mockAuthInstance();
+    const helpers = createAuthHelpers({ getAuth: () => auth });
+
+    expect(helpers).toHaveProperty("getAuthContext");
+    expect(helpers).toHaveProperty("requireAuthContext");
+    expect(helpers).toHaveProperty("getUser");
+    expect(helpers).toHaveProperty("requireUser");
+  });
+
+  describe("getAuthContext", () => {
+    it("returns user and grants when authenticated", async () => {
+      const auth = mockAuthInstance();
+      const { getAuthContext } = createAuthHelpers({ getAuth: () => auth });
+
+      const request = new Request("https://example.com/dashboard");
+      const result = await getAuthContext(request);
+
+      expect(auth.createContext).toHaveBeenCalledWith(request);
+      expect(result.user).not.toBeNull();
+      expect(result.user!.id).toBe("u1");
+      expect(result.grants).toHaveLength(1);
+    });
+
+    it("returns null user when unauthenticated", async () => {
+      const auth = mockAuthInstance({
+        createContext: vi.fn().mockResolvedValue({
+          user: null,
+          grants: [],
+        }),
+      });
+      const { getAuthContext } = createAuthHelpers({ getAuth: () => auth });
+
+      const request = new Request("https://example.com/");
+      const result = await getAuthContext(request);
+
+      expect(result.user).toBeNull();
+      expect(result.grants).toEqual([]);
+    });
+  });
+
+  describe("requireAuthContext", () => {
+    it("returns user and grants when authenticated", async () => {
+      const auth = mockAuthInstance();
+      const { requireAuthContext } = createAuthHelpers({
+        getAuth: () => auth,
+      });
+
+      const request = new Request("https://example.com/dashboard");
+      const result = await requireAuthContext(request);
+
+      expect(auth.requireUser).toHaveBeenCalledWith(request);
+      expect(result.user.id).toBe("u1");
+      expect(result.grants).toHaveLength(1);
+    });
+
+    it("propagates redirect when unauthenticated", async () => {
+      const redirectResponse = new Response(null, {
+        status: 302,
+        headers: { Location: "/login" },
+      });
+      const auth = mockAuthInstance({
+        requireUser: vi.fn().mockRejectedValue(redirectResponse),
+      });
+      const { requireAuthContext } = createAuthHelpers({
+        getAuth: () => auth,
+      });
+
+      const request = new Request("https://example.com/protected");
+
+      await expect(requireAuthContext(request)).rejects.toBe(redirectResponse);
+    });
+  });
+
+  describe("getUser", () => {
+    it("returns user when authenticated", async () => {
+      const auth = mockAuthInstance();
+      const { getUser } = createAuthHelpers({ getAuth: () => auth });
+
+      const user = await getUser(new Request("https://example.com/"));
+      expect(user).not.toBeNull();
+      expect(user!.id).toBe("u1");
+    });
+
+    it("returns null when unauthenticated", async () => {
+      const auth = mockAuthInstance({
+        createContext: vi.fn().mockResolvedValue({ user: null, grants: [] }),
+      });
+      const { getUser } = createAuthHelpers({ getAuth: () => auth });
+
+      const user = await getUser(new Request("https://example.com/"));
+      expect(user).toBeNull();
+    });
+  });
+
+  describe("requireUser", () => {
+    it("returns user when authenticated", async () => {
+      const auth = mockAuthInstance();
+      const { requireUser } = createAuthHelpers({ getAuth: () => auth });
+
+      const user = await requireUser(new Request("https://example.com/"));
+      expect(user.id).toBe("u1");
+      expect(user.email).toBe("alice@example.com");
+    });
+  });
+
+  describe("enrichUser hook", () => {
+    type StoreUser = AuthUser & { vendorId: string | null };
+
+    it("enriches user in getAuthContext", async () => {
+      const auth = mockAuthInstance();
+      const { getAuthContext } = createAuthHelpers<StoreUser>({
+        getAuth: () => auth,
+        enrichUser: async (user) => ({
+          ...user,
+          vendorId: "vendor-123",
+        }),
+      });
+
+      const result = await getAuthContext(
+        new Request("https://example.com/"),
+      );
+      expect(result.user).not.toBeNull();
+      expect(result.user!.vendorId).toBe("vendor-123");
+    });
+
+    it("enriches user in requireAuthContext", async () => {
+      const auth = mockAuthInstance();
+      const { requireAuthContext } = createAuthHelpers<StoreUser>({
+        getAuth: () => auth,
+        enrichUser: async (user) => ({
+          ...user,
+          vendorId: "vendor-456",
+        }),
+      });
+
+      const result = await requireAuthContext(
+        new Request("https://example.com/"),
+      );
+      expect(result.user.vendorId).toBe("vendor-456");
+    });
+
+    it("enriches user in getUser", async () => {
+      const auth = mockAuthInstance();
+      const { getUser } = createAuthHelpers<StoreUser>({
+        getAuth: () => auth,
+        enrichUser: async (user) => ({
+          ...user,
+          vendorId: "v-789",
+        }),
+      });
+
+      const user = await getUser(new Request("https://example.com/"));
+      expect(user).not.toBeNull();
+      expect(user!.vendorId).toBe("v-789");
+    });
+
+    it("enriches user in requireUser", async () => {
+      const auth = mockAuthInstance();
+      const { requireUser } = createAuthHelpers<StoreUser>({
+        getAuth: () => auth,
+        enrichUser: async (user) => ({
+          ...user,
+          vendorId: "v-abc",
+        }),
+      });
+
+      const user = await requireUser(new Request("https://example.com/"));
+      expect(user.vendorId).toBe("v-abc");
+    });
+
+    it("does not enrich null user in getAuthContext", async () => {
+      const enrichUser = vi.fn();
+      const auth = mockAuthInstance({
+        createContext: vi.fn().mockResolvedValue({ user: null, grants: [] }),
+      });
+      const { getAuthContext } = createAuthHelpers<StoreUser>({
+        getAuth: () => auth,
+        enrichUser,
+      });
+
+      const result = await getAuthContext(
+        new Request("https://example.com/"),
+      );
+      expect(result.user).toBeNull();
+      expect(enrichUser).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("getAuth factory is called per invocation", () => {
+    it("calls factory on each helper call", async () => {
+      const auth = mockAuthInstance();
+      const factory = vi.fn(() => auth);
+      const helpers = createAuthHelpers({ getAuth: factory });
+
+      const request = new Request("https://example.com/");
+      await helpers.getAuthContext(request);
+      await helpers.requireAuthContext(request);
+      await helpers.getUser(request);
+      await helpers.requireUser(request);
+
+      // getUser calls getAuthContext internally, so getAuth is called once per.
+      // requireUser calls requireAuthContext internally.
+      // Total: getAuthContext(1) + requireAuthContext(1) + getUser->getAuthContext(1) + requireUser->requireAuthContext(1) = 4
+      expect(factory).toHaveBeenCalledTimes(4);
+    });
+  });
+});

--- a/packages/auth/src/helpers.ts
+++ b/packages/auth/src/helpers.ts
@@ -1,0 +1,135 @@
+import type { AuthInstance, AuthContext, AuthenticatedContext, AuthUser } from "./types";
+
+/**
+ * Options for {@link createAuthHelpers}.
+ *
+ * @typeParam TUser - The application-specific user type. Defaults to
+ *   `AuthUser` when no `enrichUser` hook is provided.
+ */
+export type AuthHelpersOptions<TUser extends AuthUser = AuthUser> = {
+  /**
+   * Factory that returns an initialized `AuthInstance`.
+   *
+   * Called on every helper invocation to guarantee fresh env bindings on
+   * Cloudflare Workers (where module-scope closures can survive across
+   * requests inside the same isolate).
+   */
+  getAuth: () => AuthInstance;
+  /**
+   * Optional hook to extend the base `AuthUser` with app-specific fields
+   * (e.g., `vendorId`, custom profile data).
+   *
+   * When provided, every helper that returns a user will pass the base user
+   * through this function before returning. The enriched user type `TUser`
+   * flows through to all return types.
+   *
+   * @example
+   * ```ts
+   * const helpers = createAuthHelpers({
+   *   getAuth,
+   *   enrichUser: async (user) => {
+   *     const vendor = await lookupVendor(user.id);
+   *     return { ...user, vendorId: vendor?.id ?? null };
+   *   },
+   * });
+   * ```
+   */
+  enrichUser?: (user: AuthUser) => Promise<TUser> | TUser;
+};
+
+/**
+ * The auth helper functions returned by {@link createAuthHelpers}.
+ *
+ * @typeParam TUser - The (potentially enriched) user type.
+ */
+export type AuthHelpers<TUser extends AuthUser = AuthUser> = {
+  /** Returns the auth context for the request. User is `null` if unauthenticated. */
+  getAuthContext: (request: Request) => Promise<{ user: TUser | null; grants: AuthContext["grants"] }>;
+  /** Returns the auth context, throwing a 302 redirect if the user is not authenticated. */
+  requireAuthContext: (request: Request) => Promise<{ user: TUser; grants: AuthenticatedContext["grants"] }>;
+  /** Returns the user, or `null` if unauthenticated. */
+  getUser: (request: Request) => Promise<TUser | null>;
+  /** Returns the user, throwing a 302 redirect if not authenticated. */
+  requireUser: (request: Request) => Promise<TUser>;
+};
+
+/**
+ * Creates a set of auth helper functions that wrap an `AuthInstance`.
+ *
+ * Replaces the ~35 lines of identical `auth.helpers.server.ts` boilerplate
+ * that every cfast app copy-pastes. Apps that need to extend the user object
+ * (e.g., adding `vendorId` in the store app) pass an `enrichUser` hook.
+ *
+ * @param options - Configuration with `getAuth` factory and optional `enrichUser` hook.
+ * @returns An object with `getAuthContext`, `requireAuthContext`, `getUser`, `requireUser`.
+ *
+ * @example
+ * ```ts
+ * // app/auth.helpers.server.ts
+ * import { createAuthHelpers } from "@cfast/auth/helpers";
+ * import { initAuth } from "./auth.setup.server";
+ * import { env } from "./env";
+ *
+ * const { getAuthContext, requireAuthContext, getUser, requireUser } =
+ *   createAuthHelpers({
+ *     getAuth: () => initAuth({ d1: env.get().DB, appUrl: env.get().APP_URL }),
+ *   });
+ *
+ * export { getAuthContext, requireAuthContext, getUser, requireUser };
+ * ```
+ *
+ * @example
+ * ```ts
+ * // With enrichUser hook (e.g., store app)
+ * const helpers = createAuthHelpers({
+ *   getAuth: () => initAuth({ d1: env.get().DB, appUrl: env.get().APP_URL }),
+ *   enrichUser: async (user) => {
+ *     const vendor = await lookupVendor(user.id);
+ *     return { ...user, vendorId: vendor?.id ?? null };
+ *   },
+ * });
+ * ```
+ */
+export function createAuthHelpers<TUser extends AuthUser = AuthUser>(
+  options: AuthHelpersOptions<TUser>,
+): AuthHelpers<TUser> {
+  const { getAuth, enrichUser } = options;
+
+  async function applyEnrich(user: AuthUser): Promise<TUser> {
+    if (enrichUser) {
+      return enrichUser(user);
+    }
+    return user as TUser;
+  }
+
+  async function getAuthContext(
+    request: Request,
+  ): Promise<{ user: TUser | null; grants: AuthContext["grants"] }> {
+    const ctx = await getAuth().createContext(request);
+    if (!ctx.user) {
+      return { user: null, grants: ctx.grants };
+    }
+    const user = await applyEnrich(ctx.user);
+    return { user, grants: ctx.grants };
+  }
+
+  async function requireAuthContext(
+    request: Request,
+  ): Promise<{ user: TUser; grants: AuthenticatedContext["grants"] }> {
+    const ctx = await getAuth().requireUser(request);
+    const user = await applyEnrich(ctx.user);
+    return { user, grants: ctx.grants };
+  }
+
+  async function getUser(request: Request): Promise<TUser | null> {
+    const ctx = await getAuthContext(request);
+    return ctx.user;
+  }
+
+  async function requireUser(request: Request): Promise<TUser> {
+    const ctx = await requireAuthContext(request);
+    return ctx.user;
+  }
+
+  return { getAuthContext, requireAuthContext, getUser, requireUser };
+}

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -4,6 +4,7 @@ export { createRoleManager } from "./roles";
 export { createImpersonationManager } from "./impersonation";
 export { createAuthRouteHandlers } from "./route-handlers";
 export { createAdminAuth } from "./admin-auth";
+export { createAuthHelpers } from "./helpers";
 export type {
   AuthUser,
   AuthContext,
@@ -14,3 +15,4 @@ export type {
   AuthRolesApi,
   RoleNameOf,
 } from "./types";
+export type { AuthHelpersOptions, AuthHelpers } from "./helpers";


### PR DESCRIPTION
## Summary
- Adds `createAuthHelpers()` to `@cfast/auth/helpers` (new entrypoint) and re-exports from `@cfast/auth`
- Replaces ~35 lines of identical `auth.helpers.server.ts` boilerplate across all 4 demo apps with a single factory call
- Supports an optional `enrichUser` hook for apps like the store that extend AuthUser with custom fields (e.g. `vendorId`)

## Test plan
- [x] Unit tests added for all 4 helpers: `getAuthContext`, `requireAuthContext`, `getUser`, `requireUser`
- [x] Tests cover unauthenticated flow, enrichUser hook, null-user-not-enriched edge case
- [x] `pnpm --filter @cfast/auth test` passes (180 tests)
- [x] `pnpm --filter @cfast/auth typecheck` passes
- [ ] Demo apps can adopt by replacing `auth.helpers.server.ts` with a `createAuthHelpers()` call

Fixes #243

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)