### PR TITLE
feat(actions): type-safe clientDescriptor and useActions

### DIFF
--- a/packages/actions/src/__tests__/client-descriptor-types.test.ts
+++ b/packages/actions/src/__tests__/client-descriptor-types.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi } from "vitest";
+import type { ClientDescriptor } from "../types.js";
+
+// Mock react-router to avoid requiring a real React context
+vi.mock("react-router", () => ({
+  useLoaderData: () => ({}),
+  useFetcher: () => ({
+    state: "idle",
+    data: undefined,
+    submit: vi.fn(),
+  }),
+}));
+
+const { clientDescriptor, useActions } = await import("../client/use-actions.js");
+
+describe("clientDescriptor type safety", () => {
+  it("preserves literal action names with as const", () => {
+    const client = clientDescriptor(["create", "delete"] as const);
+
+    // Runtime check: the action names are preserved
+    expect(client.actionNames).toEqual(["create", "delete"]);
+    expect(client._brand).toBe("ActionClientDescriptor");
+
+    // Type-level check: TNames is readonly ["create", "delete"]
+    // This would fail to compile if the type parameter were lost
+    const _check: ClientDescriptor<readonly ["create", "delete"]> = client;
+    expect(_check).toBe(client);
+  });
+
+  it("infers literal types without explicit as const (const type parameter)", () => {
+    // The `const` modifier on the type parameter means callers don't need
+    // to write `as const` — the array literal is already inferred as a tuple.
+    const client = clientDescriptor(["edit", "remove"]);
+
+    expect(client.actionNames).toEqual(["edit", "remove"]);
+    const _check: ClientDescriptor<readonly ["edit", "remove"]> = client;
+    expect(_check).toBe(client);
+  });
+
+  it("useActions returns object keyed by exact action names", () => {
+    const client = clientDescriptor(["create", "delete"] as const);
+    const actions = useActions(client);
+
+    // Runtime: both keys exist
+    expect(typeof actions.create).toBe("function");
+    expect(typeof actions.delete).toBe("function");
+
+    // Type-level: accessing a valid action works
+    const createHook = actions.create();
+    expect(createHook).toHaveProperty("permitted");
+    expect(createHook).toHaveProperty("submit");
+
+    const deleteHook = actions.delete();
+    expect(deleteHook).toHaveProperty("permitted");
+  });
+
+  it("remains backward-compatible with plain string arrays", () => {
+    const names: string[] = ["a", "b"];
+    // Should compile without error even with a non-literal array
+    const client = clientDescriptor(names);
+
+    expect(client.actionNames).toEqual(["a", "b"]);
+  });
+});

--- a/packages/actions/src/client/use-actions.ts
+++ b/packages/actions/src/client/use-actions.ts
@@ -10,10 +10,18 @@ import type {
  * Creates a ClientDescriptor for use in client code without importing
  * server modules. The action names must match the keys passed to
  * `composeActions` or the single action name from `createAction`.
+ *
+ * Pass a `readonly` tuple (`as const`) to get compile-time type-checking
+ * of action names throughout the client code:
+ *
+ * ```ts
+ * const client = clientDescriptor(["create", "delete"] as const);
+ * // client is ClientDescriptor<readonly ["create", "delete"]>
+ * ```
  */
-export function clientDescriptor(
-  actionNames: readonly string[],
-): ClientDescriptor {
+export function clientDescriptor<const TNames extends readonly string[]>(
+  actionNames: TNames,
+): ClientDescriptor<TNames> {
   return {
     _brand: "ActionClientDescriptor",
     actionNames,
@@ -73,9 +81,9 @@ function extractPermissions(loaderData: Record<string, unknown>): ActionPermissi
   return map;
 }
 
-export function useActions(
-  descriptor: ClientDescriptor,
-): Record<string, (input?: Serializable) => ActionHookResult> {
+export function useActions<const TNames extends readonly string[]>(
+  descriptor: ClientDescriptor<TNames>,
+): { [K in TNames[number]]: (input?: Serializable) => ActionHookResult } {
   const loaderData = asRecord(useLoaderData());
   const permissions = extractPermissions(loaderData);
 
@@ -116,5 +124,5 @@ export function useActions(
     });
   }
 
-  return result;
+  return result as { [K in TNames[number]]: (input?: Serializable) => ActionHookResult };
 }

--- a/packages/actions/src/types.ts
+++ b/packages/actions/src/types.ts
@@ -241,11 +241,11 @@ export type ActionPermissionsMap = Record<string, ActionPermissionStatus>;
  * Created by {@link ActionDefinition.client} or {@link ComposedActions.client}.
  * Contains the action names and the key used to read permission data from loader results.
  */
-export type ClientDescriptor = {
+export type ClientDescriptor<TNames extends readonly string[] = readonly string[]> = {
   /** Brand field to distinguish this type at the type level. */
   _brand: "ActionClientDescriptor";
   /** The list of action names this descriptor covers. */
-  actionNames: readonly string[];
+  actionNames: TNames;
   /** The loader-data key where {@link ActionPermissionsMap} is stored. */
   permissionsKey: string;
 };


### PR DESCRIPTION
## Summary
- Makes `ClientDescriptor` generic over action name string literals (`ClientDescriptor<TNames>`)
- `clientDescriptor(["create", "delete"] as const)` now preserves the tuple type via `const` type parameter
- `useActions()` returns a mapped type `{ [K in TNames[number]]: ... }` instead of `Record<string, ...>`, catching action name typos at compile time
- Fully backward-compatible: the default type parameter is `readonly string[]`

Closes #246

## Test plan
- [x] All 112 existing tests pass
- [x] New `client-descriptor-types.test.ts` verifies literal type preservation and backward compatibility
- [x] `tsc --noEmit` passes cleanly

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)