### PR TITLE
feat(core): add createDefaultPlugins preset for auth + db plugin chain

### DIFF
--- a/packages/core/llms.txt
+++ b/packages/core/llms.txt
@@ -138,6 +138,50 @@ with it slot into existing `app.use()` calls without further changes. If you
 prefer to type a single plugin in-place without a factory, import the
 `PluginContext<Env, TRequires>` helper and annotate the parameter directly.
 
+### Presets (`@cfast/core/presets`)
+
+```typescript
+import { createDefaultPlugins } from "@cfast/core/presets";
+
+function createDefaultPlugins(config: {
+  initAuth: (env: Record<string, unknown>) => AuthInstanceLike;
+  createDb: (grants: Grant[], user: { id: string } | null) => Db;
+}): { authPlugin, dbPlugin }
+```
+
+Creates the standard auth + db plugin pair that every cfast app uses. Replaces ~50 lines of identical plugin definitions across `cfast.server.ts` in every demo app.
+
+The auth plugin calls `initAuth(ctx.env)` per-request and returns `{ user, grants, instance }` under `ctx.auth`. The db plugin depends on the auth plugin and calls `createDb(grants, user)` to return `{ client }` under `ctx.db`.
+
+```typescript
+import { createApp } from "@cfast/core";
+import { createDefaultPlugins } from "@cfast/core/presets";
+import { envSchema } from "./env";
+import { permissions } from "./permissions";
+import { initAuth } from "./auth.setup.server";
+import { appDb } from "./db/client";
+
+const { authPlugin, dbPlugin } = createDefaultPlugins({
+  initAuth: (env) => initAuth({
+    d1: env.DB as D1Database,
+    appUrl: env.APP_URL as string,
+  }),
+  createDb: (grants, user) => appDb(grants, user),
+});
+
+export const app = createApp({ env: envSchema, permissions })
+  .use(authPlugin)
+  .use(dbPlugin);
+// Add app-specific plugins after the defaults:
+//  .use(storagePlugin)
+//  .use(emailPlugin);
+```
+
+Also re-exported from `@cfast/core` main entry for convenience:
+```typescript
+import { createDefaultPlugins } from "@cfast/core";
+```
+
 ### Client (`@cfast/core/client`)
 
 ```typescript

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -26,6 +26,10 @@
     "./client": {
       "import": "./dist/client/index.js",
       "types": "./dist/client/index.d.ts"
+    },
+    "./presets": {
+      "import": "./dist/presets.js",
+      "types": "./dist/presets.d.ts"
     }
   },
   "files": [
@@ -37,8 +41,8 @@
     "access": "public"
   },
   "scripts": {
-    "build": "tsup src/index.ts src/client/index.ts --format esm --dts",
-    "dev": "tsup src/index.ts src/client/index.ts --format esm --dts --watch",
+    "build": "tsup src/index.ts src/client/index.ts src/presets.ts --format esm --dts",
+    "dev": "tsup src/index.ts src/client/index.ts src/presets.ts --format esm --dts --watch",
     "typecheck": "tsc --noEmit",
     "lint": "eslint src/",
     "test": "vitest run --passWithNoTests"

--- a/packages/core/src/__tests__/presets.test.ts
+++ b/packages/core/src/__tests__/presets.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi } from "vitest";
+import { createDefaultPlugins } from "../presets";
+
+function mockAuthInstance(
+  user: { id: string; email: string; name: string } | null = {
+    id: "u1",
+    email: "alice@example.com",
+    name: "Alice",
+  },
+) {
+  return {
+    createContext: vi.fn().mockResolvedValue({
+      user: user ? { ...user, avatarUrl: null, roles: ["admin"] } : null,
+      grants: user ? [{ action: "manage" as const, subject: "all" as const }] : [],
+    }),
+  };
+}
+
+describe("createDefaultPlugins", () => {
+  it("returns authPlugin and dbPlugin", () => {
+    const { authPlugin, dbPlugin } = createDefaultPlugins({
+      initAuth: () => mockAuthInstance(),
+      createDb: vi.fn(() => ({ query: vi.fn() })),
+    });
+    expect(authPlugin.name).toBe("auth");
+    expect(dbPlugin.name).toBe("db");
+  });
+
+  describe("authPlugin", () => {
+    it("calls initAuth with env and returns user/grants/instance", async () => {
+      const auth = mockAuthInstance();
+      const initAuth = vi.fn(() => auth);
+      const { authPlugin } = createDefaultPlugins({ initAuth, createDb: vi.fn() });
+      const request = new Request("https://example.com/");
+      const env = { DB: "d1-mock", APP_URL: "https://example.com" };
+      const result = await authPlugin.setup({ request, env } as Parameters<typeof authPlugin.setup>[0]);
+      expect(initAuth).toHaveBeenCalledWith(env);
+      expect(auth.createContext).toHaveBeenCalledWith(request);
+      expect(result.user).not.toBeNull();
+      expect(result.user!.id).toBe("u1");
+      expect(result.grants).toHaveLength(1);
+      expect(result.instance).toBe(auth);
+    });
+
+    it("returns null user when unauthenticated", async () => {
+      const auth = mockAuthInstance(null);
+      const { authPlugin } = createDefaultPlugins({ initAuth: () => auth, createDb: vi.fn() });
+      const result = await authPlugin.setup({ request: new Request("https://example.com/"), env: {} } as Parameters<typeof authPlugin.setup>[0]);
+      expect(result.user).toBeNull();
+      expect(result.grants).toEqual([]);
+    });
+  });
+
+  describe("dbPlugin", () => {
+    it("calls createDb with grants and user from auth", async () => {
+      const dbMock = { query: vi.fn() };
+      const createDb = vi.fn(() => dbMock);
+      const auth = mockAuthInstance();
+      const { authPlugin, dbPlugin } = createDefaultPlugins({ initAuth: () => auth, createDb });
+      const request = new Request("https://example.com/");
+      const env = { DB: "d1-mock" };
+      const authResult = await authPlugin.setup({ request, env } as Parameters<typeof authPlugin.setup>[0]);
+      const dbResult = await dbPlugin.setup({ request, env, auth: authResult } as Parameters<typeof dbPlugin.setup>[0]);
+      expect(createDb).toHaveBeenCalledWith(authResult.grants, { id: "u1" });
+      expect(dbResult.client).toBe(dbMock);
+    });
+
+    it("passes null user when unauthenticated", async () => {
+      const createDb = vi.fn(() => ({}));
+      const auth = mockAuthInstance(null);
+      const { authPlugin, dbPlugin } = createDefaultPlugins({ initAuth: () => auth, createDb });
+      const request = new Request("https://example.com/");
+      const authResult = await authPlugin.setup({ request, env: {} } as Parameters<typeof authPlugin.setup>[0]);
+      await dbPlugin.setup({ request, env: {}, auth: authResult } as Parameters<typeof dbPlugin.setup>[0]);
+      expect(createDb).toHaveBeenCalledWith([], null);
+    });
+  });
+
+  describe("dbPlugin requires authPlugin", () => {
+    it("dbPlugin declares authPlugin as a dependency", () => {
+      const { authPlugin, dbPlugin } = createDefaultPlugins({ initAuth: () => mockAuthInstance(), createDb: vi.fn() });
+      expect(dbPlugin.requires).toBeDefined();
+      expect(dbPlugin.requires).toContain(authPlugin);
+    });
+  });
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -2,6 +2,7 @@
 // @cfast/core — app composition layer with plugin system
 export { createApp } from "./create-app";
 export { definePlugin, definePluginFor } from "./define-plugin";
+export { createDefaultPlugins } from "./presets";
 export { CfastPluginError, CfastConfigError } from "./errors";
 export type {
   CfastPlugin,
@@ -13,3 +14,8 @@ export type {
   App,
   RouteArgs,
 } from "./types";
+export type {
+  DefaultPluginsConfig,
+  DefaultAuthProvides,
+  DefaultDbProvides,
+} from "./presets";

--- a/packages/core/src/presets.ts
+++ b/packages/core/src/presets.ts
@@ -1,0 +1,55 @@
+import type { Grant } from "@cfast/permissions";
+import { definePlugin } from "./define-plugin";
+
+type AuthInstanceLike = {
+  createContext: (request: Request) => Promise<{
+    user: { id: string; email: string; name: string; [key: string]: unknown } | null;
+    grants: Grant[];
+  }>;
+};
+
+type DbFactory = (grants: Grant[], user: { id: string } | null) => unknown;
+
+export type DefaultPluginsConfig = {
+  initAuth: (env: Record<string, unknown>) => AuthInstanceLike;
+  createDb: DbFactory;
+};
+
+export type DefaultAuthProvides = {
+  user: { id: string; email: string; name: string; [key: string]: unknown } | null;
+  grants: Grant[];
+  instance: AuthInstanceLike;
+};
+
+export type DefaultDbProvides = {
+  client: unknown;
+};
+
+export function createDefaultPlugins(config: DefaultPluginsConfig) {
+  const authPlugin = definePlugin({
+    name: "auth" as const,
+    async setup(ctx: { request: Request; env: Record<string, unknown> }) {
+      const auth = config.initAuth(ctx.env);
+      const authCtx = await auth.createContext(ctx.request);
+      return {
+        user: authCtx.user,
+        grants: authCtx.grants,
+        instance: auth,
+      };
+    },
+  });
+
+  const dbPlugin = definePlugin({
+    name: "db" as const,
+    requires: [authPlugin],
+    setup(ctx) {
+      const client = config.createDb(
+        ctx.auth.grants,
+        ctx.auth.user ? { id: ctx.auth.user.id } : null,
+      );
+      return { client };
+    },
+  });
+
+  return { authPlugin, dbPlugin };
+}


### PR DESCRIPTION
## Summary
- Adds `createDefaultPlugins({ initAuth, createDb })` to `@cfast/core/presets` (new entrypoint) and re-exports from `@cfast/core`
- Replaces ~50 lines of identical authPlugin + dbPlugin definitions that every demo app copy-pastes in `cfast.server.ts`
- Apps still register plugins individually via `.use()` and can add app-specific plugins (storage, email) after the defaults

## Test plan
- [x] Unit tests cover authPlugin setup (authenticated + unauthenticated), dbPlugin setup, dependency declaration
- [x] `pnpm --filter @cfast/core test` passes (63 tests across 6 test files)
- [x] `pnpm --filter @cfast/core typecheck` passes
- [ ] Demo apps can adopt by replacing manual plugin definitions with `createDefaultPlugins()`

Fixes #244

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)