### PR TITLE
feat: add @cfast/test-e2e shared Playwright infrastructure

### DIFF
--- a/packages/test-e2e/package.json
+++ b/packages/test-e2e/package.json
@@ -1,0 +1,58 @@
+{
+  "name": "@cfast/test-e2e",
+  "version": "0.1.0",
+  "description": "Shared Playwright config, helpers, and smoke tests for cfast apps",
+  "keywords": [
+    "cfast",
+    "playwright",
+    "e2e",
+    "testing"
+  ],
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/DanielMSchmidt/cfast.git",
+    "directory": "packages/test-e2e"
+  },
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    },
+    "./config": {
+      "import": "./dist/config.js",
+      "types": "./dist/config.d.ts"
+    },
+    "./smoke": {
+      "import": "./dist/smoke.js",
+      "types": "./dist/smoke.d.ts"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "sideEffects": false,
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "build": "tsup src/index.ts src/config.ts src/smoke.ts --format esm --dts",
+    "dev": "tsup src/index.ts src/config.ts src/smoke.ts --format esm --dts --watch",
+    "typecheck": "tsc --noEmit",
+    "lint": "eslint src/",
+    "test": "vitest run"
+  },
+  "peerDependencies": {
+    "@playwright/test": ">=1.40.0"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.52.0",
+    "@types/node": "^22",
+    "tsup": "^8",
+    "typescript": "^5.7",
+    "vitest": "^4.1.0"
+  }
+}

--- a/packages/test-e2e/src/__tests__/discover-routes.test.ts
+++ b/packages/test-e2e/src/__tests__/discover-routes.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { join } from "node:path";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+
+import { discoverRoutes } from "../smoke.js";
+
+describe("discoverRoutes", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "cfast-test-e2e-"));
+    mkdirSync(join(tmpDir, "app"), { recursive: true });
+  });
+
+  function writeRoutesFile(content: string) {
+    writeFileSync(join(tmpDir, "app", "routes.ts"), content, "utf-8");
+  }
+
+  it("discovers index route", () => {
+    writeRoutesFile(`
+      import { index } from "@react-router/dev/routes";
+      export default [index("routes/_index.tsx")];
+    `);
+    expect(discoverRoutes(tmpDir)).toEqual(["/"]);
+  });
+
+  it("discovers named routes", () => {
+    writeRoutesFile(`
+      import { index, route } from "@react-router/dev/routes";
+      export default [
+        index("routes/_index.tsx"),
+        route("about", "routes/about.tsx"),
+        route("settings", "routes/settings.tsx"),
+      ];
+    `);
+    expect(discoverRoutes(tmpDir)).toEqual(["/", "/about", "/settings"]);
+  });
+
+  it("skips dynamic routes with :id", () => {
+    writeRoutesFile(`
+      import { index, route } from "@react-router/dev/routes";
+      export default [
+        index("routes/_index.tsx"),
+        route("posts/:postId", "routes/post-detail.tsx"),
+        route("about", "routes/about.tsx"),
+      ];
+    `);
+    expect(discoverRoutes(tmpDir)).toEqual(["/", "/about"]);
+  });
+
+  it("skips wildcard routes with *", () => {
+    writeRoutesFile(`
+      import { route } from "@react-router/dev/routes";
+      export default [
+        route("files/*", "routes/file-browser.tsx"),
+        route("admin", "routes/admin.tsx"),
+      ];
+    `);
+    expect(discoverRoutes(tmpDir)).toEqual(["/admin"]);
+  });
+
+  it("returns empty array when no routes found", () => {
+    writeRoutesFile(`export default [];`);
+    expect(discoverRoutes(tmpDir)).toEqual([]);
+  });
+});

--- a/packages/test-e2e/src/__tests__/discover-routes.test.ts
+++ b/packages/test-e2e/src/__tests__/discover-routes.test.ts
@@ -1,6 +1,6 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach } from "vitest";
 import { join } from "node:path";
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 
 import { discoverRoutes } from "../smoke.js";

--- a/packages/test-e2e/src/config.ts
+++ b/packages/test-e2e/src/config.ts
@@ -1,0 +1,76 @@
+import { defineConfig, type PlaywrightTestConfig } from "@playwright/test";
+
+export type CfastPlaywrightConfigOptions = {
+  /** Local dev server port. Defaults to 5173. */
+  port?: number;
+  /** Dev server start command. Defaults to "pnpm dev". */
+  command?: string;
+  /** Test directory relative to the config file. Defaults to ".". */
+  testDir?: string;
+  /** Test timeout in milliseconds. Defaults to 30_000. */
+  timeout?: number;
+  /** Dev server startup timeout in milliseconds. Defaults to 120_000. */
+  serverTimeout?: number;
+  /** Additional Playwright config to merge. */
+  overrides?: Partial<PlaywrightTestConfig>;
+};
+
+/**
+ * Creates a shared Playwright config for cfast apps.
+ *
+ * Provides sensible defaults matching the cfast convention:
+ * - Local-first: baseURL defaults to localhost, with `E2E_BASE_URL` override
+ * - Auto-starts dev server when running locally
+ * - Chromium-only for speed
+ * - Traces on first retry, screenshots on failure
+ *
+ * @example
+ * ```ts
+ * // e2e/playwright.config.ts
+ * import { createPlaywrightConfig } from "@cfast/test-e2e/config";
+ * export default createPlaywrightConfig();
+ * ```
+ *
+ * @example With custom port
+ * ```ts
+ * export default createPlaywrightConfig({ port: 3000 });
+ * ```
+ */
+export function createPlaywrightConfig(
+  options: CfastPlaywrightConfigOptions = {},
+): PlaywrightTestConfig {
+  const {
+    port = 5173,
+    command = "pnpm dev",
+    testDir = ".",
+    timeout = 30_000,
+    serverTimeout = 120_000,
+    overrides = {},
+  } = options;
+
+  const LOCAL_BASE_URL = `http://localhost:${port}`;
+  const baseURL = process.env.E2E_BASE_URL ?? LOCAL_BASE_URL;
+  const isLocal = baseURL === LOCAL_BASE_URL;
+
+  return defineConfig({
+    testDir,
+    timeout,
+    use: {
+      baseURL,
+      trace: "on-first-retry",
+      screenshot: "only-on-failure",
+    },
+    webServer: isLocal
+      ? {
+          command,
+          url: LOCAL_BASE_URL,
+          reuseExistingServer: !process.env.CI,
+          timeout: serverTimeout,
+          stdout: "pipe",
+          stderr: "pipe",
+        }
+      : undefined,
+    projects: [{ name: "chromium", use: { browserName: "chromium" } }],
+    ...overrides,
+  });
+}

--- a/packages/test-e2e/src/helpers.ts
+++ b/packages/test-e2e/src/helpers.ts
@@ -1,0 +1,28 @@
+import { expect, type Page, type Response } from "@playwright/test";
+
+/**
+ * Like `page.goto()` but throws if the response is a 4xx/5xx (other than
+ * 401/403 which mean "the route exists, you're not authorized").
+ *
+ * Use this in feature specs to fail loudly on routing regressions instead
+ * of getting a confusing locator timeout deeper in the test.
+ *
+ * @example
+ * ```ts
+ * import { gotoOk } from "@cfast/test-e2e";
+ *
+ * test("dashboard loads", async ({ page }) => {
+ *   await gotoOk(page, "/dashboard");
+ *   await expect(page.locator("h1")).toHaveText("Dashboard");
+ * });
+ * ```
+ */
+export async function gotoOk(page: Page, path: string): Promise<Response> {
+  const response = await page.goto(path);
+  expect(response, `no response for ${path}`).not.toBeNull();
+  const status = response!.status();
+  if (status >= 400 && status !== 401 && status !== 403) {
+    throw new Error(`gotoOk("${path}") got status ${status}`);
+  }
+  return response!;
+}

--- a/packages/test-e2e/src/index.ts
+++ b/packages/test-e2e/src/index.ts
@@ -1,0 +1,6 @@
+/** @module test-e2e */
+export { gotoOk } from "./helpers.js";
+export { createPlaywrightConfig } from "./config.js";
+export type { CfastPlaywrightConfigOptions } from "./config.js";
+export { registerSmokeTests, discoverRoutes } from "./smoke.js";
+export type { SmokeTestOptions } from "./smoke.js";

--- a/packages/test-e2e/src/smoke.ts
+++ b/packages/test-e2e/src/smoke.ts
@@ -1,0 +1,83 @@
+import { test, expect } from "@playwright/test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+export type SmokeTestOptions = {
+  /**
+   * Absolute path to the project root directory (the directory containing
+   * `app/routes.ts`). Typically pass `__dirname` or use `fileURLToPath`.
+   *
+   * @example
+   * ```ts
+   * import { dirname } from "node:path";
+   * import { fileURLToPath } from "node:url";
+   * const HERE = dirname(fileURLToPath(import.meta.url));
+   * registerSmokeTests({ projectRoot: join(HERE, "..") });
+   * ```
+   */
+  projectRoot: string;
+};
+
+/**
+ * Auto-discovers routes from `app/routes.ts` and returns their paths.
+ *
+ * Matches:
+ * - `index("routes/_index.tsx")` -> "/"
+ * - `route("foo", "routes/foo.tsx")` -> "/foo"
+ *
+ * Skips dynamic routes (`:id`, `*`) that cannot be resolved for a smoke test.
+ */
+export function discoverRoutes(projectRoot: string): string[] {
+  const file = readFileSync(join(projectRoot, "app", "routes.ts"), "utf-8");
+  const routes: string[] = [];
+  if (/index\(/.test(file)) routes.push("/");
+  const routeMatches = file.matchAll(/route\(\s*["']([^"']+)["']/g);
+  for (const m of routeMatches) {
+    const path = m[1];
+    if (path.includes(":") || path.includes("*")) continue;
+    routes.push(`/${path}`);
+  }
+  return routes;
+}
+
+/**
+ * Registers Playwright smoke tests that verify every discovered route:
+ * - Returns HTTP < 400 (or 401/403 for protected routes)
+ * - Body does NOT contain placeholder strings or absolute filesystem paths
+ *
+ * Call this in your `smoke.spec.ts`:
+ * ```ts
+ * import { registerSmokeTests } from "@cfast/test-e2e/smoke";
+ * import { dirname, join } from "node:path";
+ * import { fileURLToPath } from "node:url";
+ *
+ * const HERE = dirname(fileURLToPath(import.meta.url));
+ * registerSmokeTests({ projectRoot: join(HERE, "..") });
+ * ```
+ */
+export function registerSmokeTests(options: SmokeTestOptions): void {
+  const ROUTES = discoverRoutes(options.projectRoot);
+
+  const OK = (code: number) => code < 400 || code === 401 || code === 403;
+
+  for (const path of ROUTES) {
+    test(`route ${path} is registered and responds`, async ({ page }) => {
+      const response = await page.goto(path);
+      expect(response, `no response for ${path}`).not.toBeNull();
+      const status = response!.status();
+      expect(OK(status), `${path} returned ${status}`).toBe(true);
+
+      // Catch placeholder pages even if status is 200
+      const body = await page.content();
+      expect(body, `${path} contains scaffold placeholder`).not.toContain(
+        "Get started by editing",
+      );
+      expect(body, `${path} leaks absolute filesystem path`).not.toContain("/Users/");
+      expect(body, `${path} leaks absolute filesystem path`).not.toContain("/home/");
+    });
+  }
+
+  test(`smoke: discovered ${ROUTES.length} routes`, async () => {
+    expect(ROUTES.length, "no routes discovered from app/routes.ts").toBeGreaterThan(0);
+  });
+}

--- a/packages/test-e2e/tsconfig.json
+++ b/packages/test-e2e/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "types": ["node"]
+  },
+  "include": ["src"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1274,6 +1274,24 @@ importers:
         specifier: ^4.1.0
         version: 4.1.0(@types/node@24.12.0)(jsdom@28.1.0(@noble/hashes@2.0.1))(vite@8.0.0(@types/node@24.12.0)(esbuild@0.27.3)(tsx@4.21.0)(yaml@2.8.2))
 
+  packages/test-e2e:
+    devDependencies:
+      '@playwright/test':
+        specifier: ^1.52.0
+        version: 1.58.2
+      '@types/node':
+        specifier: ^22
+        version: 22.19.13
+      tsup:
+        specifier: ^8
+        version: 8.5.1(postcss@8.5.8)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
+      typescript:
+        specifier: ^5.7
+        version: 5.9.3
+      vitest:
+        specifier: ^4.1.0
+        version: 4.1.0(@types/node@22.19.13)(jsdom@29.0.1(@noble/hashes@2.0.1))(vite@8.0.0(@types/node@22.19.13)(esbuild@0.27.3)(tsx@4.21.0)(yaml@2.8.2))
+
   packages/ui:
     devDependencies:
       '@cfast/actions':
@@ -9894,7 +9912,6 @@ snapshots:
       magic-string: 0.30.21
     optionalDependencies:
       vite: 8.0.0(@types/node@22.19.13)(esbuild@0.27.3)(tsx@4.21.0)(yaml@2.8.2)
-    optional: true
 
   '@vitest/mocker@4.1.0(vite@8.0.0(@types/node@24.12.0)(esbuild@0.25.12)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
@@ -13622,7 +13639,6 @@ snapshots:
       jsdom: 29.0.1(@noble/hashes@2.0.1)
     transitivePeerDependencies:
       - msw
-    optional: true
 
   vitest@4.1.0(@types/node@24.12.0)(jsdom@26.1.0)(vite@8.0.0(@types/node@24.12.0)(esbuild@0.25.12)(tsx@4.21.0)(yaml@2.8.2)):
     dependencies:

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -17,6 +17,7 @@
     "packages/pagination": { "component": "@cfast/pagination" },
     "packages/permissions": { "component": "@cfast/permissions" },
     "packages/storage": { "component": "@cfast/storage" },
+    "packages/test-e2e": { "component": "@cfast/test-e2e" },
     "packages/ui": { "component": "@cfast/ui" }
   }
 }


### PR DESCRIPTION
## Summary
- New `@cfast/test-e2e` package extracting ~416 lines of duplicated e2e test infrastructure across all 4 demo apps
- `createPlaywrightConfig()`: shared config factory with local-first defaults, `E2E_BASE_URL` override, and auto dev server startup
- `gotoOk()`: navigation helper that fails on 4xx/5xx (except 401/403)
- `registerSmokeTests()`: auto-discovers routes from `app/routes.ts` and verifies each responds without scaffold placeholders or leaked filesystem paths
- `discoverRoutes()`: exported separately for custom test compositions
- Added to `release-please-config.json` for automated releases

Closes #245

## Test plan
- [x] 5 unit tests for `discoverRoutes()` covering index, named, dynamic, wildcard, and empty routes
- [x] `tsc --noEmit` passes
- [x] `tsup` build produces correct ESM + DTS output
- [ ] Follow-up: update demo apps to import from `@cfast/test-e2e` instead of local copies

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)