### PR TITLE
feat(db): add toJSON() for automatic Date-to-ISO-string conversion

### DIFF
--- a/packages/db/llms.txt
+++ b/packages/db/llms.txt
@@ -631,6 +631,30 @@ export default defineConfig({
 });
 ```
 
+### toJSON(value): DateToString<T>
+
+Recursively converts `Date` fields to ISO 8601 strings for JSON serialization.
+React Router loaders must return JSON-serializable data; `toJSON()` makes the
+Date-to-string conversion explicit so every loader doesn't need manual
+`.toISOString()` calls.
+
+```typescript
+import { toJSON } from "@cfast/db";
+
+export async function loader({ context }) {
+  const db = createDb({ ... });
+  const posts = await db.query(postsTable).findMany().run();
+  // Date fields (createdAt, updatedAt, etc.) become ISO strings automatically.
+  return { posts: toJSON(posts) };
+}
+```
+
+The return type `DateToString<T>` maps every `Date` property to `string` at the
+type level, so the client sees accurate types without manual casting.
+
+Works on plain objects, arrays, nested structures, and single Date values.
+Non-Date primitives pass through unchanged.
+
 ## Common Mistakes
 
 - **Forgetting `.run()`** -- Operations are lazy. `db.query(t).findMany()` returns an Operation, not results. You must call `.run()`.

--- a/packages/db/src/__tests__/json.test.ts
+++ b/packages/db/src/__tests__/json.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from "vitest";
+import { toJSON } from "../json";
+
+describe("toJSON", () => {
+  it("converts Date fields to ISO strings in a plain object", () => {
+    const date = new Date("2025-01-15T10:30:00.000Z");
+    const row = { id: "1", title: "Hello", createdAt: date, count: 42 };
+    const result = toJSON(row);
+
+    expect(result).toEqual({
+      id: "1",
+      title: "Hello",
+      createdAt: "2025-01-15T10:30:00.000Z",
+      count: 42,
+    });
+    expect(typeof result.createdAt).toBe("string");
+  });
+
+  it("converts Date fields in an array of objects", () => {
+    const rows = [
+      { id: "1", createdAt: new Date("2025-01-01T00:00:00Z") },
+      { id: "2", createdAt: new Date("2025-06-15T12:00:00Z") },
+    ];
+    const result = toJSON(rows);
+
+    expect(result).toEqual([
+      { id: "1", createdAt: "2025-01-01T00:00:00.000Z" },
+      { id: "2", createdAt: "2025-06-15T12:00:00.000Z" },
+    ]);
+  });
+
+  it("handles nested objects", () => {
+    const row = {
+      id: "1",
+      author: {
+        name: "Alice",
+        joinedAt: new Date("2024-01-01T00:00:00Z"),
+      },
+    };
+    const result = toJSON(row);
+
+    expect(result).toEqual({
+      id: "1",
+      author: {
+        name: "Alice",
+        joinedAt: "2024-01-01T00:00:00.000Z",
+      },
+    });
+  });
+
+  it("handles a single Date value", () => {
+    const date = new Date("2025-03-20T08:00:00Z");
+    expect(toJSON(date)).toBe("2025-03-20T08:00:00.000Z");
+  });
+
+  it("passes through primitives unchanged", () => {
+    expect(toJSON("hello")).toBe("hello");
+    expect(toJSON(42)).toBe(42);
+    expect(toJSON(true)).toBe(true);
+    expect(toJSON(null)).toBe(null);
+    expect(toJSON(undefined)).toBe(undefined);
+  });
+
+  it("handles empty arrays and objects", () => {
+    expect(toJSON([])).toEqual([]);
+    expect(toJSON({})).toEqual({});
+  });
+
+  it("handles objects without Date fields (no-op)", () => {
+    const row = { id: "1", title: "Hello", count: 42 };
+    expect(toJSON(row)).toEqual(row);
+  });
+
+  it("handles nested arrays", () => {
+    const data = {
+      posts: [
+        { id: "1", createdAt: new Date("2025-01-01T00:00:00Z") },
+      ],
+    };
+    const result = toJSON(data);
+    expect(result.posts[0].createdAt).toBe("2025-01-01T00:00:00.000Z");
+  });
+});

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -6,6 +6,8 @@ export { parseCursorParams, parseOffsetParams } from "./paginate";
 export { TransactionError } from "./transaction";
 export { defineSeed } from "./seed";
 export type { Seed, SeedConfig, SeedEntry } from "./seed";
+export { toJSON } from "./json";
+export type { DateToString } from "./json";
 export { runWithLookupCache, createLookupCache } from "./utils";
 export type { LookupCache } from "./utils";
 export type {

--- a/packages/db/src/json.ts
+++ b/packages/db/src/json.ts
@@ -1,0 +1,74 @@
+/**
+ * Recursively converts Date fields in a value to ISO 8601 strings for
+ * JSON serialization.
+ *
+ * React Router loaders must return JSON-serializable data. Date objects
+ * are not JSON-serializable by default -- `JSON.stringify(new Date())`
+ * calls `Date.prototype.toJSON()` which produces an ISO string, but the
+ * resulting value on the client is a string, not a Date. This helper
+ * makes the conversion explicit and type-safe so every loader doesn't
+ * need to manually call `.toISOString()` on every date field.
+ *
+ * Works on:
+ * - Plain objects (shallow and nested)
+ * - Arrays of objects
+ * - Single Date values
+ * - Nested arrays and objects of arbitrary depth
+ *
+ * Non-Date primitives (string, number, boolean, null, undefined) pass
+ * through unchanged. The function is a no-op for values that don't
+ * contain Date instances.
+ *
+ * @param value - The value to convert. Typically a query result row or
+ *   array of rows from `db.query(...).findMany().run()`.
+ * @returns A new value with every Date replaced by its ISO string.
+ *
+ * @example
+ * ```ts
+ * import { toJSON } from "@cfast/db";
+ *
+ * export async function loader({ context }) {
+ *   const db = createDb({ ... });
+ *   const posts = await db.query(postsTable).findMany().run();
+ *   return { posts: toJSON(posts) };
+ * }
+ * ```
+ */
+export function toJSON<T>(value: T): DateToString<T> {
+  return convertDates(value) as DateToString<T>;
+}
+
+function convertDates(value: unknown): unknown {
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+
+  if (Array.isArray(value)) {
+    return value.map(convertDates);
+  }
+
+  if (value !== null && typeof value === "object") {
+    const result: Record<string, unknown> = {};
+    for (const [key, val] of Object.entries(value)) {
+      result[key] = convertDates(val);
+    }
+    return result;
+  }
+
+  return value;
+}
+
+/**
+ * Type-level utility that converts Date fields to string in a type.
+ *
+ * Maps `{ createdAt: Date; title: string }` to
+ * `{ createdAt: string; title: string }` so the return type of
+ * `toJSON(row)` accurately reflects the runtime shape.
+ */
+export type DateToString<T> = T extends Date
+  ? string
+  : T extends Array<infer U>
+    ? DateToString<U>[]
+    : T extends Record<string, unknown>
+      ? { [K in keyof T]: DateToString<T[K]> }
+      : T;


### PR DESCRIPTION
## Summary
- Adds `toJSON(value)` utility that recursively converts `Date` fields to ISO 8601 strings
- Includes `DateToString<T>` mapped type for accurate client-side typing
- Eliminates manual `.toISOString()` calls in every React Router loader

## Usage
```ts
import { toJSON } from "@cfast/db";

export async function loader({ context }) {
  const db = createDb({ ... });
  const posts = await db.query(postsTable).findMany().run();
  return { posts: toJSON(posts) };
}
```

## Test plan
- [ ] 8 new unit tests for toJSON covering objects, arrays, nesting, primitives, edge cases
- [ ] All 209 tests pass (`pnpm test` in packages/db)
- [ ] Typecheck passes

Fixes #242

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)