### PR TITLE
docs: update docs for merged auth helpers, admin adapter, type-safe actions, presets, test-e2e, .with() inference, toJSON

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -12,5 +12,6 @@
   "packages/pagination": "0.2.0",
   "packages/permissions": "0.5.1",
   "packages/storage": "0.2.1",
+  "packages/test-e2e": "0.1.0",
   "packages/ui": "0.3.1"
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,7 +132,14 @@ This repo uses **release-please** with conventional commits. The commit prefix d
 
 Fix all CI failures including unrelated ones — do not leave the build broken.
 
-## LLM Documentation
+## Documentation
+
+Every PR that adds or changes public APIs MUST update documentation as part of the same PR:
+
+1. Update the affected package's `packages/*/llms.txt`
+2. Update root `llms.txt` and `llms-full.txt` if cross-package patterns change
+3. Update the CLAUDE.md template in `packages/create-cfast/templates/base/CLAUDE.md` if conventions change
+4. Update `docs/` site content if user-facing guides are affected
 
 This project ships `llms.txt` files for LLM consumption:
 - Root `llms.txt` — concise project overview
@@ -140,7 +147,4 @@ This project ships `llms.txt` files for LLM consumption:
 - Per-package `packages/*/llms.txt` — focused per-package docs
 - Scaffolded `CLAUDE.md` — template in `packages/create-cfast/templates/base/CLAUDE.md`
 
-When adding or changing public APIs:
-1. Update the affected package's `llms.txt`
-2. Update root `llms.txt` and `llms-full.txt` if cross-package patterns change
-3. Update the CLAUDE.md template if conventions change
+Do not create separate "docs update" PRs — documentation changes ship with the code they describe.

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -588,6 +588,71 @@ await db.cache.invalidate({ tables: ["posts"] });
 
 Clears the per-instance cross-table `with` lookup cache. Use in tests that reuse a `Db` across grant inserts -- call after modifying grants so subsequent queries re-run `with` lookups. Prefer `runWithLookupCache()` in production; use `clearLookupCache()` for quick manual resets in tests.
 
+### Auto-Inferred `.with()` Relations
+
+When you pass `with: { relation: true }`, Drizzle's relational query builder embeds the joined rows into the result. As of `@cfast/db@0.5`, the result type is **automatically inferred** from the schema -- no type cast needed. `createDb` captures the full schema type via a generic, and `findMany`/`findFirst` thread the `with` config through Drizzle's `BuildQueryResult` to compute the exact result shape including nested relations.
+
+```typescript
+const db = createDb({ d1, schema, grants, user });
+
+// Auto-inferred -- no cast, no manual generic
+const recipes = await db
+  .query(schema.recipesTable)
+  .findMany({ with: { ingredients: true } })
+  .run();
+// recipes is { id: string; title: string; ingredients: Ingredient[] }[]
+
+// Nested relations work too
+const plan = await db
+  .query(schema.mealPlans)
+  .findFirst({
+    with: { entries: { with: { recipe: { with: { ingredients: true } } } } },
+  })
+  .run();
+// plan.entries[0].recipe.ingredients is fully typed
+```
+
+**Manual override:** pass `<TConfig, TRow>` to override when needed:
+
+```typescript
+type Custom = Recipe & { ingredients: Ingredient[] };
+const recipes = await db
+  .query(recipesTable)
+  .findMany<{ with: { ingredients: true } }, Custom>({
+    with: { ingredients: true },
+  })
+  .run();
+```
+
+### `toJSON(value): DateToString<T>`
+
+```typescript
+import { toJSON } from "@cfast/db";
+
+function toJSON<T>(value: T): DateToString<T>
+
+type DateToString<T> = T extends Date
+  ? string
+  : T extends Array<infer U>
+    ? DateToString<U>[]
+    : T extends Record<string, unknown>
+      ? { [K in keyof T]: DateToString<T[K]> }
+      : T;
+```
+
+Recursively converts `Date` fields to ISO 8601 strings for JSON serialization. React Router loaders must return JSON-serializable data; `toJSON()` makes the Date-to-string conversion explicit so every loader doesn't need manual `.toISOString()` calls.
+
+```typescript
+export async function loader({ context }) {
+  const db = createDb({ ... });
+  const posts = await db.query(postsTable).findMany().run();
+  // Date fields (createdAt, updatedAt) become ISO strings automatically.
+  return { posts: toJSON(posts) };
+}
+```
+
+The return type `DateToString<T>` maps every `Date` property to `string` at the type level, so the client sees accurate types without manual casting. Works on plain objects, arrays, nested structures, and single Date values. Non-Date primitives pass through unchanged.
+
 ### Known Limitations
 
 1. **`.run()` params not type-safe** -- `Record<string, unknown>` (optional, defaults to `{}`), Drizzle validates at runtime
@@ -807,10 +872,58 @@ const admin = await createAdmin({
 
 The factory pattern (`getAuth` instead of a static instance) ensures each operation gets fresh Cloudflare Workers bindings, avoiding stale references after cold starts.
 
+### `createAuthHelpers(options)`
+
+```typescript
+import { createAuthHelpers } from "@cfast/auth/helpers";
+// Also re-exported from "@cfast/auth" main entry
+
+function createAuthHelpers<TUser extends AuthUser = AuthUser>(options: {
+  getAuth: () => AuthInstance;
+  enrichUser?: (user: AuthUser) => Promise<TUser> | TUser;
+}): {
+  getAuthContext: (request: Request) => Promise<{ user: TUser | null; grants: Grant[] }>;
+  requireAuthContext: (request: Request) => Promise<{ user: TUser; grants: Grant[] }>;
+  getUser: (request: Request) => Promise<TUser | null>;
+  requireUser: (request: Request) => Promise<TUser>;
+}
+```
+
+Replaces the ~35-line `auth.helpers.server.ts` boilerplate every cfast app copy-pastes. The `getAuth` factory is called per-request to get fresh Workers env bindings.
+
+The optional `enrichUser` hook lets apps extend the base `AuthUser` with custom fields (e.g., `vendorId` in a marketplace). When provided, every helper passes the user through `enrichUser` before returning.
+
+**Basic usage (most apps):**
+
+```typescript
+import { createAuthHelpers } from "@cfast/auth/helpers";
+import { initAuth } from "./auth.setup.server";
+import { env } from "./env";
+
+export const { getAuthContext, requireAuthContext, getUser, requireUser } =
+  createAuthHelpers({
+    getAuth: () => initAuth({ d1: env.get().DB, appUrl: env.get().APP_URL }),
+  });
+```
+
+**With enrichUser (marketplace / multi-tenant apps):**
+
+```typescript
+export const { getAuthContext, requireAuthContext, getUser, requireUser } =
+  createAuthHelpers<StoreUser>({
+    getAuth: () => initAuth({ d1: env.get().DB, appUrl: env.get().APP_URL }),
+    enrichUser: async (user) => {
+      const vendor = await lookupVendor(user.id);
+      return { ...user, vendorId: vendor?.id ?? null };
+    },
+  });
+```
+
 ### Package Exports
 
 ```
-@cfast/auth          -> createAuth, createAdminAuth, createRoleManager, createImpersonationManager, createAuthRouteHandlers
+@cfast/auth          -> createAuth, createAdminAuth, createAuthHelpers, createRoleManager, createImpersonationManager, createAuthRouteHandlers
+@cfast/auth/helpers  -> createAuthHelpers
 @cfast/auth/client   -> AuthProvider, AuthClientProvider, AuthGuard, LoginPage, useCurrentUser, useAuth, createAuthClient
 @cfast/auth/plugin   -> authRoutes() for routes.ts
 @cfast/auth/schema   -> Drizzle auth tables for migrations
@@ -1164,11 +1277,43 @@ await createRow.dispatch({
 
 Permission checks still run on the sub-action's operation. Use `forwardRequest()` only when you must go through the full HTTP handler (e.g., cross-Worker calls).
 
+### Type-Safe `clientDescriptor()` and `useActions()`
+
+`clientDescriptor()` now uses `const` type parameters to infer the literal tuple type from the action names array. `useActions()` returns a mapped type keyed by those literal names instead of `Record<string, ...>`.
+
+```typescript
+import { clientDescriptor, useActions } from "@cfast/actions/client";
+
+// Type-safe: autocomplete and typo-checking on action names
+const client = clientDescriptor(["create", "delete"]);
+// client is ClientDescriptor<readonly ["create", "delete"]>
+
+const actions = useActions(client);
+// actions is { create: (input?) => ActionHookResult; delete: (input?) => ActionHookResult }
+// actions.creat → TypeScript error (caught at compile time)
+```
+
+```typescript
+function clientDescriptor<const TNames extends readonly string[]>(
+  actionNames: TNames,
+): ClientDescriptor<TNames>;
+
+function useActions<const TNames extends readonly string[]>(
+  descriptor: ClientDescriptor<TNames>,
+): { [K in TNames[number]]: (input?: Serializable) => ActionHookResult };
+
+type ClientDescriptor<TNames extends readonly string[] = readonly string[]> = {
+  _brand: "ActionClientDescriptor";
+  actionNames: TNames;
+  permissionsKey: string;
+};
+```
+
 ### Exports
 
 ```
 @cfast/actions         -> createActions, checkPermissionStatus
-@cfast/actions/client  -> useActions, ActionForm
+@cfast/actions/client  -> useActions, clientDescriptor, ActionForm
 ```
 
 ---
@@ -1851,7 +1996,7 @@ const auth: AdminAuthConfig = {
 };
 ```
 
-**Or use `createAdminAuth()` (recommended):**
+**Or use `createAdminAuth()` from `@cfast/auth` (recommended):**
 
 ```typescript
 import { createAdminAuth } from "@cfast/auth";
@@ -1859,6 +2004,25 @@ import { createAdminAuth } from "@cfast/auth";
 const auth = createAdminAuth(() => initAuth({ d1: env.DB, appUrl: env.APP_URL }));
 // Implements all AdminAuthConfig methods automatically
 ```
+
+**Or use `createAdminAuthAdapter()` from `@cfast/admin` (same result, different import):**
+
+```typescript
+import { createAdminAuthAdapter } from "@cfast/admin";
+
+const auth = createAdminAuthAdapter({
+  getAuth: () => initAuth({ d1: env.get().DB, appUrl: env.get().APP_URL }),
+});
+// Also available from: import { createAdminAuthAdapter } from "@cfast/admin/server"
+```
+
+`createAdminAuthAdapter({ getAuth })` creates a complete `AdminAuthConfig` from a single auth-instance factory. Replaces ~50 lines of manual adapter boilerplate per app. The factory is called per-operation to ensure fresh env bindings on Workers.
+
+| Param | Type | Description |
+|---|---|---|
+| `options.getAuth` | `() => AuthInstanceLike` | Factory called per-operation for fresh Workers env bindings |
+
+**Returns:** `AdminAuthConfig` with `requireUser`, `hasRole`, `getRoles`, `setRole`, `removeRole`, `setRoles`.
 
 ### Server/Client Splitting
 
@@ -2304,6 +2468,43 @@ export const rateLimitPlugin = (config: { kv: string; maxRequests: number; windo
   });
 ```
 
+### `createDefaultPlugins(config)` (Presets)
+
+```typescript
+import { createDefaultPlugins } from "@cfast/core/presets";
+// Also re-exported from "@cfast/core" main entry
+
+function createDefaultPlugins(config: {
+  initAuth: (env: Record<string, unknown>) => AuthInstanceLike;
+  createDb: (grants: Grant[], user: { id: string } | null) => Db;
+}): { authPlugin: CfastPlugin; dbPlugin: CfastPlugin }
+```
+
+Creates the standard auth + db plugin pair that every cfast app uses. Replaces ~50 lines of identical plugin definitions across `cfast.server.ts` in every app.
+
+The auth plugin calls `initAuth(ctx.env)` per-request and returns `{ user, grants, instance }` under `ctx.auth`. The db plugin depends on the auth plugin and calls `createDb(grants, user)` to return `{ client }` under `ctx.db`.
+
+```typescript
+import { createApp } from "@cfast/core";
+import { createDefaultPlugins } from "@cfast/core/presets";
+import { envSchema } from "./env";
+import { permissions } from "./permissions";
+import { initAuth } from "./auth.setup.server";
+import { appDb } from "./db/client";
+
+const { authPlugin, dbPlugin } = createDefaultPlugins({
+  initAuth: (env) => initAuth({
+    d1: env.DB as D1Database,
+    appUrl: env.APP_URL as string,
+  }),
+  createDb: (grants, user) => appDb(grants, user),
+});
+
+export const app = createApp({ env: envSchema, permissions })
+  .use(authPlugin)
+  .use(dbPlugin);
+```
+
 ### Startup Validation
 
 - Duplicate plugin names -> `CfastConfigError` thrown at `.use()` time
@@ -2313,8 +2514,9 @@ export const rateLimitPlugin = (config: { kv: string; maxRequests: number; windo
 ### Exports
 
 ```
-@cfast/core         -> createApp, definePlugin, CfastPluginError, CfastConfigError
-@cfast/core/client  -> useApp, createCoreProvider, CoreContext
+@cfast/core          -> createApp, definePlugin, createDefaultPlugins, CfastPluginError, CfastConfigError
+@cfast/core/presets  -> createDefaultPlugins
+@cfast/core/client   -> useApp, createCoreProvider, CoreContext
 ```
 
 ### Known Limitations
@@ -2375,6 +2577,102 @@ pnpm deploy:production
 - Multi-action route (create + delete)
 - Auto-generated form from Drizzle schema
 - Welcome email sent after registration
+
+---
+
+## @cfast/test-e2e
+
+Shared Playwright configuration and test utilities for cfast apps.
+
+### `createPlaywrightConfig(options?)`
+
+```typescript
+import { createPlaywrightConfig } from "@cfast/test-e2e";
+
+function createPlaywrightConfig(options?: CfastPlaywrightConfigOptions): PlaywrightTestConfig
+```
+
+Creates a shared Playwright config with cfast conventions: local-first baseURL, auto-start dev server, Chromium-only, traces on first retry, screenshots on failure.
+
+```typescript
+type CfastPlaywrightConfigOptions = {
+  port?: number;           // default: 5173
+  command?: string;        // default: "pnpm dev"
+  testDir?: string;        // default: "."
+  timeout?: number;        // default: 30_000
+  serverTimeout?: number;  // default: 120_000
+  overrides?: Partial<PlaywrightTestConfig>;  // merged into the final config
+};
+```
+
+```typescript
+// e2e/playwright.config.ts
+import { createPlaywrightConfig } from "@cfast/test-e2e";
+export default createPlaywrightConfig();
+
+// With custom port
+export default createPlaywrightConfig({ port: 3000 });
+```
+
+When `E2E_BASE_URL` is set, the dev server is not started (for CI against deployed environments).
+
+### `gotoOk(page, path)`
+
+```typescript
+import { gotoOk } from "@cfast/test-e2e";
+
+async function gotoOk(page: Page, path: string): Promise<Response>
+```
+
+Like `page.goto()` but throws if the response is 4xx/5xx (except 401/403 which mean "route exists, not authorized"). Use in feature specs to fail loudly on routing regressions.
+
+```typescript
+test("dashboard loads", async ({ page }) => {
+  await gotoOk(page, "/dashboard");
+  await expect(page.locator("h1")).toHaveText("Dashboard");
+});
+```
+
+### `registerSmokeTests(options)`
+
+```typescript
+import { registerSmokeTests } from "@cfast/test-e2e";
+
+function registerSmokeTests(options: SmokeTestOptions): void
+
+type SmokeTestOptions = {
+  projectRoot: string;  // absolute path to project root (contains app/routes.ts)
+};
+```
+
+Auto-discovers routes from `app/routes.ts` and registers a Playwright test for each that verifies:
+- HTTP status < 400 (or 401/403 for protected routes)
+- Body does not contain scaffold placeholder strings
+- Body does not leak absolute filesystem paths (`/Users/`, `/home/`)
+
+```typescript
+// e2e/smoke.spec.ts
+import { registerSmokeTests } from "@cfast/test-e2e";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+registerSmokeTests({ projectRoot: join(HERE, "..") });
+```
+
+### `discoverRoutes(projectRoot)`
+
+```typescript
+function discoverRoutes(projectRoot: string): string[]
+```
+
+Reads `app/routes.ts` and returns static route paths. Matches `index(...)` as `"/"` and `route("path", ...)` as `"/path"`. Skips dynamic routes (`:id`, `*`).
+
+### Exports
+
+```
+@cfast/test-e2e  -> createPlaywrightConfig, gotoOk, registerSmokeTests, discoverRoutes
+```
 
 ---
 

--- a/llms.txt
+++ b/llms.txt
@@ -35,20 +35,23 @@ cfast is a monorepo of packages that share three core philosophies:
 ### Core Infrastructure
 - [`@cfast/env`](https://github.com/DanielMSchmidt/cfast/tree/main/packages/env): Type-safe Cloudflare bindings with runtime validation at startup. `defineEnv()` -> `env.init(rawEnv)` -> `env.get()`.
 - [`@cfast/permissions`](https://github.com/DanielMSchmidt/cfast/tree/main/packages/permissions): Isomorphic permission system. `definePermissions<User, typeof schema>({ schema })(...)` + `grant(action, subject, { where })`. Accepts both string subjects (JS key or SQL name — both resolved at startup) and table objects; compiles to Drizzle WHERE clauses. `can(grants, action, table)` for quick grant-level boolean checks.
-- [`@cfast/db`](https://github.com/DanielMSchmidt/cfast/tree/main/packages/db): Permission-aware Drizzle queries. `createDb({ d1, schema, grants, user })` returns lazy `Operation` objects with `.permissions` and `.run()` (params optional, defaults to `{}`). `composeSequential(ops)` shorthand for running operations in order.
-- [`@cfast/auth`](https://github.com/DanielMSchmidt/cfast/tree/main/packages/auth): Authentication via Better Auth. Magic email + passkeys. Role management, impersonation. `createAuth({ permissions })`. `createAdminAuth(getAuth)` builds admin auth adapter from auth instance factory.
+- [`@cfast/db`](https://github.com/DanielMSchmidt/cfast/tree/main/packages/db): Permission-aware Drizzle queries. `createDb({ d1, schema, grants, user })` returns lazy `Operation` objects with `.permissions` and `.run()` (params optional, defaults to `{}`). `composeSequential(ops)` shorthand for running operations in order. `.with()` relations are now auto-inferred from the schema (no casts). `toJSON(value)` converts Date fields to ISO strings for loader returns; `DateToString<T>` mapped type.
+- [`@cfast/auth`](https://github.com/DanielMSchmidt/cfast/tree/main/packages/auth): Authentication via Better Auth. Magic email + passkeys. Role management, impersonation. `createAuth({ permissions })`. `createAdminAuth(getAuth)` builds admin auth adapter from auth instance factory. `createAuthHelpers({ getAuth })` from `@cfast/auth/helpers` replaces per-app boilerplate with `{ getAuthContext, requireAuthContext, getUser, requireUser }` — optional `enrichUser` hook extends the user object.
 - [`@cfast/storage`](https://github.com/DanielMSchmidt/cfast/tree/main/packages/storage): Schema-driven R2 file uploads. `defineStorage()` + `filetype()`. Multipart, validation, client `useUpload()` hook.
 
 ### UI & DX
-- [`@cfast/actions`](https://github.com/DanielMSchmidt/cfast/tree/main/packages/actions): Multi-action routes. `createAction()` returns `.action` (server handler), `.loader()` (injects permissions), `.client` (for `useActions()` hook). `ActionForm` auto-injects hidden fields from action input.
+- [`@cfast/actions`](https://github.com/DanielMSchmidt/cfast/tree/main/packages/actions): Multi-action routes. `createAction()` returns `.action` (server handler), `.loader()` (injects permissions), `.client` (for `useActions()` hook). `ActionForm` auto-injects hidden fields from action input. `clientDescriptor(["create", "delete"])` now infers literal tuple types; `useActions()` returns a mapped type keyed by those names instead of `Record<string, ...>`.
 - [`@cfast/forms`](https://github.com/DanielMSchmidt/cfast/tree/main/packages/forms): Auto-generated forms from Drizzle schema. `<AutoForm table={posts} />`. Supports nested parent-child tables with full type inference (`nested: [{ table: ingredients, foreignKey: "recipeId", min: 1 }]` → `onSubmit` receives a fully-typed `values.ingredients`) and computed fields (`fields: { total: { computed: (v) => ..., readOnly: true } }`). Plugin-based rendering (Joy UI ships built-in).
 - [`@cfast/ui`](https://github.com/DanielMSchmidt/cfast/tree/main/packages/ui): Permission-aware components. DataTable, FilterBar, ListView, DetailView, ActionButton, PermissionGate, AppShell, DropZone. Headless core + Joy UI plugin.
 - [`@cfast/pagination`](https://github.com/DanielMSchmidt/cfast/tree/main/packages/pagination): Cursor-based, offset-based pagination, infinite scroll. Server helpers in `@cfast/db`, client hooks here.
-- [`@cfast/admin`](https://github.com/DanielMSchmidt/cfast/tree/main/packages/admin): Auto-generated admin UI from Drizzle schema. One route = full admin. Uses `@cfast/ui` for rendering, `@cfast/db` for data, `@cfast/auth` for user management.
+- [`@cfast/admin`](https://github.com/DanielMSchmidt/cfast/tree/main/packages/admin): Auto-generated admin UI from Drizzle schema. One route = full admin. Uses `@cfast/ui` for rendering, `@cfast/db` for data, `@cfast/auth` for user management. `createAdminAuthAdapter({ getAuth })` creates a complete `AdminAuthConfig` from a single auth factory — replaces ~50 lines of boilerplate per app.
 - [`@cfast/email`](https://github.com/DanielMSchmidt/cfast/tree/main/packages/email): Workers-native email. react-email rendering + pluggable providers (Mailgun, console). `createEmailClient({ provider })`.
 
+### Testing
+- [`@cfast/test-e2e`](https://github.com/DanielMSchmidt/cfast/tree/main/packages/test-e2e): Shared Playwright config and test utilities. `createPlaywrightConfig()` — convention-driven config factory (local-first, Chromium-only). `gotoOk(page, path)` — navigation helper that fails on 4xx/5xx. `registerSmokeTests({ projectRoot })` — auto-discovers routes for smoke tests.
+
 ### Composition & Tooling
-- [`@cfast/core`](https://github.com/DanielMSchmidt/cfast/tree/main/packages/core): Optional app object. `createApp().use(plugin)` wires per-request context + client provider tree.
+- [`@cfast/core`](https://github.com/DanielMSchmidt/cfast/tree/main/packages/core): Optional app object. `createApp().use(plugin)` wires per-request context + client provider tree. `createDefaultPlugins({ initAuth, createDb })` from `@cfast/core/presets` returns the standard `{ authPlugin, dbPlugin }` pair — replaces ~50 lines of identical plugin definitions per app.
 - [`create-cfast`](https://github.com/DanielMSchmidt/cfast/tree/main/packages/create-cfast): Scaffolder. `npm create cfast@latest my-app`.
 
 ## End-to-End Example
@@ -138,3 +141,4 @@ pnpm dev
 - [`@cfast/admin` docs](https://github.com/DanielMSchmidt/cfast/tree/main/packages/admin): Admin panel
 - [`@cfast/email` docs](https://github.com/DanielMSchmidt/cfast/tree/main/packages/email): Email sending
 - [`@cfast/core` docs](https://github.com/DanielMSchmidt/cfast/tree/main/packages/core): App composition
+- [`@cfast/test-e2e` docs](https://github.com/DanielMSchmidt/cfast/tree/main/packages/test-e2e): Playwright test utilities

--- a/packages/actions/llms.txt
+++ b/packages/actions/llms.txt
@@ -68,9 +68,31 @@ type ActionPermissionsMap = Record<string, ActionPermissionStatus>;
 
 ### Client (`@cfast/actions/client`)
 
+#### Type-safe `clientDescriptor()` and `useActions()`
+
+`clientDescriptor()` now uses `const` type parameters to infer the literal tuple
+type from the action names array. `useActions()` returns a mapped type keyed by
+those literal names instead of `Record<string, ...>`, giving compile-time
+autocomplete and error checking on action names.
+
 ```typescript
-function useActions(descriptor: ClientDescriptor): Record<string, (input?: Serializable) => ActionHookResult>;
-function clientDescriptor(actionNames: readonly string[]): ClientDescriptor;
+// Type-safe: actions.create and actions.delete are typed, typos are caught
+const client = clientDescriptor(["create", "delete"]);
+// client is ClientDescriptor<readonly ["create", "delete"]>
+
+const actions = useActions(client);
+// actions is { create: (input?) => ActionHookResult; delete: (input?) => ActionHookResult }
+// actions.creat → TypeScript error (typo caught at compile time)
+```
+
+```typescript
+function useActions<const TNames extends readonly string[]>(
+  descriptor: ClientDescriptor<TNames>,
+): { [K in TNames[number]]: (input?: Serializable) => ActionHookResult };
+
+function clientDescriptor<const TNames extends readonly string[]>(
+  actionNames: TNames,
+): ClientDescriptor<TNames>;
 
 function ActionForm(props: ActionFormProps): JSX.Element;
 

--- a/packages/create-cfast/templates/base/CLAUDE.md
+++ b/packages/create-cfast/templates/base/CLAUDE.md
@@ -107,10 +107,9 @@ Use field overrides when calling the form generator:
 
 ## E2E Tests Are Local-First
 
-- `playwright.config.ts` `baseURL` MUST default to `http://localhost:5173`. Pointing the default at a deployed URL is forbidden — it makes passes meaningless on a fresh checkout.
-- `playwright.config.ts` MUST include a `webServer` block with `reuseExistingServer: !process.env.CI`.
-- Every new route MUST be implicitly covered by `e2e/smoke.spec.ts` (which auto-discovers routes from `app/routes.ts`). Do not delete this spec.
-- For feature specs, use `gotoOk(page, path)` from `e2e/helpers.ts` instead of raw `page.goto()` so 4xx surfaces as a routing failure, not a selector timeout.
+- Use `createPlaywrightConfig()` from `@cfast/test-e2e` for the Playwright config. It defaults to `http://localhost:5173` with a `webServer` block that auto-starts `pnpm dev`. Override with `E2E_BASE_URL` for deployed environments.
+- Every new route MUST be implicitly covered by `e2e/smoke.spec.ts` (which uses `registerSmokeTests()` from `@cfast/test-e2e` to auto-discover routes from `app/routes.ts`). Do not delete this spec.
+- For feature specs, use `gotoOk(page, path)` from `@cfast/test-e2e` instead of raw `page.goto()` so 4xx surfaces as a routing failure, not a selector timeout.
 - `test.skip(...)` is only acceptable for tests requiring external services (real email, real OAuth). It is NOT a substitute for a fixture; authenticated tests should use the test helpers from `@cfast/auth/test-helpers`.
 
 ## Anti-Patterns — Do NOT Do These
@@ -190,4 +189,4 @@ For detailed API reference on any cfast package, check:
 
 Available packages: `@cfast/env`, `@cfast/permissions`, `@cfast/auth`, `@cfast/db`,
 `@cfast/actions`, `@cfast/ui`, `@cfast/forms`, `@cfast/pagination`, `@cfast/storage`,
-`@cfast/email`, `@cfast/admin`.
+`@cfast/email`, `@cfast/admin`, `@cfast/test-e2e`.

--- a/packages/test-e2e/llms.txt
+++ b/packages/test-e2e/llms.txt
@@ -1,0 +1,152 @@
+# @cfast/test-e2e
+
+> Shared Playwright configuration and test utilities for cfast apps. Convention-driven: local-first, Chromium-only, auto-discovers routes for smoke tests.
+
+## When to use
+
+Use `@cfast/test-e2e` in any cfast app that has end-to-end tests with Playwright. It provides a shared config factory, a navigation helper that surfaces routing regressions early, and an auto-discovery smoke test runner.
+
+## Key concepts
+
+- **Local-first.** `createPlaywrightConfig()` defaults to `http://localhost:5173` with a `webServer` block that auto-starts `pnpm dev`. Override with `E2E_BASE_URL` for CI against deployed environments.
+- **Route auto-discovery.** `discoverRoutes()` reads `app/routes.ts` and extracts static route paths. `registerSmokeTests()` registers a Playwright test for each discovered route.
+- **Fail-fast navigation.** `gotoOk()` throws on 4xx/5xx (except 401/403) instead of letting the test silently proceed to a confusing locator timeout.
+
+## API Reference
+
+### createPlaywrightConfig(options?)
+
+```typescript
+import { createPlaywrightConfig } from "@cfast/test-e2e";
+
+function createPlaywrightConfig(options?: CfastPlaywrightConfigOptions): PlaywrightTestConfig
+```
+
+Creates a shared Playwright config with cfast conventions: local-first baseURL, auto-start dev server, Chromium-only, traces on first retry, screenshots on failure.
+
+```typescript
+type CfastPlaywrightConfigOptions = {
+  port?: number;           // default: 5173
+  command?: string;        // default: "pnpm dev"
+  testDir?: string;        // default: "."
+  timeout?: number;        // default: 30_000
+  serverTimeout?: number;  // default: 120_000
+  overrides?: Partial<PlaywrightTestConfig>;
+};
+```
+
+```typescript
+// e2e/playwright.config.ts
+import { createPlaywrightConfig } from "@cfast/test-e2e";
+export default createPlaywrightConfig();
+
+// With custom port
+export default createPlaywrightConfig({ port: 3000 });
+```
+
+When `E2E_BASE_URL` is set, the dev server is not started (for CI against deployed environments).
+
+### gotoOk(page, path)
+
+```typescript
+import { gotoOk } from "@cfast/test-e2e";
+
+async function gotoOk(page: Page, path: string): Promise<Response>
+```
+
+Like `page.goto()` but throws if the response is 4xx/5xx (except 401/403 which mean "route exists, not authorized"). Use in feature specs to fail on routing regressions instead of getting confusing locator timeouts.
+
+```typescript
+test("dashboard loads", async ({ page }) => {
+  await gotoOk(page, "/dashboard");
+  await expect(page.locator("h1")).toHaveText("Dashboard");
+});
+```
+
+### registerSmokeTests(options)
+
+```typescript
+import { registerSmokeTests } from "@cfast/test-e2e";
+
+function registerSmokeTests(options: SmokeTestOptions): void
+```
+
+Auto-discovers routes from `app/routes.ts` and registers a Playwright test for each that verifies:
+- HTTP status < 400 (or 401/403 for protected routes)
+- Body does not contain scaffold placeholders or leaked filesystem paths
+
+```typescript
+type SmokeTestOptions = {
+  projectRoot: string;  // absolute path to project root (contains app/routes.ts)
+};
+```
+
+```typescript
+// e2e/smoke.spec.ts
+import { registerSmokeTests } from "@cfast/test-e2e";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+registerSmokeTests({ projectRoot: join(HERE, "..") });
+```
+
+### discoverRoutes(projectRoot)
+
+```typescript
+import { discoverRoutes } from "@cfast/test-e2e";
+
+function discoverRoutes(projectRoot: string): string[]
+```
+
+Reads `app/routes.ts` and returns an array of static route paths. Matches `index(...)` as `"/"` and `route("path", ...)` as `"/path"`. Skips dynamic routes (`:id`, `*`) that cannot be resolved for smoke tests.
+
+## Usage Examples
+
+### Minimal Playwright config
+
+```typescript
+// e2e/playwright.config.ts
+import { createPlaywrightConfig } from "@cfast/test-e2e";
+export default createPlaywrightConfig();
+```
+
+### Smoke tests with auto-discovery
+
+```typescript
+// e2e/smoke.spec.ts
+import { registerSmokeTests } from "@cfast/test-e2e";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+registerSmokeTests({ projectRoot: join(HERE, "..") });
+```
+
+### Feature spec with gotoOk
+
+```typescript
+import { test, expect } from "@playwright/test";
+import { gotoOk } from "@cfast/test-e2e";
+
+test("projects page renders", async ({ page }) => {
+  await gotoOk(page, "/projects");
+  await expect(page.locator("h1")).toContainText("Projects");
+});
+```
+
+## Integration
+
+- **@cfast/auth/test-helpers** -- Use auth test helpers to get authenticated cookies, then pass them to Playwright pages for testing protected routes.
+- **@cfast/auth/test-helpers/passkey** -- Use passkey test helpers for browser-based auth in E2E tests (Chromium-only, same constraint as this package).
+
+## Common Mistakes
+
+- **Not registering routes in `app/routes.ts`** -- React Router v7 has no auto-discovery. `discoverRoutes()` reads `app/routes.ts`, so unregistered routes won't be smoke tested.
+- **Pointing `baseURL` at a deployed URL by default** -- Keep the default local; use `E2E_BASE_URL` env var for deployed environments.
+- **Using `page.goto()` instead of `gotoOk()`** -- Raw `page.goto()` silently proceeds on 404s, causing confusing locator timeouts instead of clear routing failures.
+
+## See Also
+
+- `@cfast/auth/test-helpers` -- Real-workflow helpers for driving the magic-link flow from tests.
+- `@cfast/auth/test-helpers/passkey` -- Passkey test helpers for Playwright E2E tests.


### PR DESCRIPTION
## Summary

- **Root `llms.txt`**: Added concise entries for `createAuthHelpers()`, `createAdminAuthAdapter()`, type-safe `clientDescriptor()`, `createDefaultPlugins()`, `.with()` auto-inference, `toJSON()`, and the new `@cfast/test-e2e` package
- **Root `llms-full.txt`**: Added full API reference sections for all new APIs — `createAuthHelpers` (auth), `createAdminAuthAdapter` (admin), type-safe `clientDescriptor`/`useActions` (actions), `createDefaultPlugins` (core/presets), auto-inferred `.with()` relations + `toJSON`/`DateToString` (db), and the complete `@cfast/test-e2e` package
- **`packages/actions/llms.txt`**: Updated `clientDescriptor()` and `useActions()` signatures to reflect `const` type parameters and mapped return type
- **`packages/test-e2e/llms.txt`**: Created new file — full docs for `createPlaywrightConfig`, `gotoOk`, `registerSmokeTests`, `discoverRoutes`
- **`packages/create-cfast/templates/base/CLAUDE.md`**: Added `@cfast/test-e2e` to available packages list, updated E2E section to reference `@cfast/test-e2e` utilities
- **`CLAUDE.md`**: Renamed "LLM Documentation" to "Documentation", added rule that docs must ship with the code in the same PR
- **`.release-please-manifest.json`**: Added `packages/test-e2e: 0.1.0` entry

Per-package `llms.txt` files for auth, admin, core, and db were already updated by their respective feature PRs (#265-#273) and are left as-is.

## Test plan

- [ ] Verify root `llms.txt` renders correctly and links are valid
- [ ] Verify `llms-full.txt` API sections are complete and code examples compile conceptually
- [ ] Verify `packages/test-e2e/llms.txt` covers all public exports
- [ ] Verify `packages/actions/llms.txt` type signatures match actual source
- [ ] Verify `CLAUDE.md` documentation section is coherent
- [ ] Verify scaffolded `CLAUDE.md` template lists all packages

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)