### PR TITLE
fix: update create-cfast test snapshots

### DIFF
--- a/packages/create-cfast/src/__tests__/smoke-spec-extraction.test.ts
+++ b/packages/create-cfast/src/__tests__/smoke-spec-extraction.test.ts
@@ -176,7 +176,7 @@ describe("scaffold ships e2e infrastructure", () => {
     const targetDir = scaffoldFixture("docs");
     const claudeMd = fs.readFileSync(path.join(targetDir, "CLAUDE.md"), "utf-8");
     expect(claudeMd).toContain("E2E Tests Are Local-First");
-    expect(claudeMd).toContain("baseURL` MUST default to `http://localhost:5173`");
+    expect(claudeMd).toContain("defaults to `http://localhost:5173`");
     expect(claudeMd).toContain("webServer");
     expect(claudeMd).toContain("smoke.spec.ts");
     expect(claudeMd).toContain("gotoOk");


### PR DESCRIPTION
## Summary

- Updates a `toContain` assertion in `smoke-spec-extraction.test.ts` to match the rewritten CLAUDE.md template from #275
- The old assertion expected `baseURL` MUST default to `http://localhost:5173`` but the new template uses `defaults to `http://localhost:5173``

## Test plan

- [x] `pnpm vitest run src/__tests__/smoke-spec-extraction.test.ts` passes (14/14 tests)
- [ ] CI `create-cfast#test` should now pass


🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)