### PR TITLE
chore(examples): adopt latest @cfast/* APIs in team-blog-after

### DIFF
--- a/examples/team-blog-after/app/admin.server.ts
+++ b/examples/team-blog-after/app/admin.server.ts
@@ -1,5 +1,4 @@
-import { createAdminLoader, createAdminAction, introspectSchema } from "@cfast/admin";
-import { createAdminAuth } from "@cfast/auth";
+import { createAdminLoader, createAdminAction, createAdminAuthAdapter, introspectSchema } from "@cfast/admin";
 import { initAuth } from "~/auth.setup.server";
 import { env } from "~/env";
 import { appDb } from "~/cfast.server";
@@ -9,9 +8,9 @@ import * as schema from "~/db/schema";
 // Admin auth adapter — one line instead of ~150
 // ---------------------------------------------------------------------------
 
-const auth = createAdminAuth(() =>
-  initAuth({ d1: env.get().DB, appUrl: env.get().APP_URL })
-);
+const auth = createAdminAuthAdapter({
+  getAuth: () => initAuth({ d1: env.get().DB, appUrl: env.get().APP_URL }),
+});
 
 // ---------------------------------------------------------------------------
 // DB factory — reused from cfast.server.ts

--- a/examples/team-blog-after/app/auth.helpers.server.ts
+++ b/examples/team-blog-after/app/auth.helpers.server.ts
@@ -1,37 +1,14 @@
+import { createAuthHelpers } from "@cfast/auth/helpers";
 import { initAuth } from "./auth.setup.server";
 import { env } from "./env";
-import type { Grant } from "@cfast/permissions";
-import type { AuthUser } from "./permissions";
 
 export type { UserRole } from "./permissions";
 export type { AuthUser } from "./permissions";
-
-// App-specific auth context types using the local AuthUser
-export type AuthContext = { user: AuthUser | null; grants: Grant[] };
-export type AuthenticatedContext = { user: AuthUser; grants: Grant[] };
 
 function getAuth() {
   const e = env.get();
   return initAuth({ d1: e.DB, appUrl: e.APP_URL });
 }
 
-export async function getAuthContext(request: Request): Promise<AuthContext> {
-  const ctx = await getAuth().createContext(request);
-  return ctx as AuthContext;
-}
-
-export async function requireAuthContext(request: Request): Promise<AuthenticatedContext> {
-  const ctx = await getAuth().requireUser(request);
-  return ctx as AuthenticatedContext;
-}
-
-// Convenience: get just the user (for routes that don't need grants)
-export async function getUser(request: Request): Promise<AuthUser | null> {
-  const ctx = await getAuthContext(request);
-  return ctx.user;
-}
-
-export async function requireUser(request: Request): Promise<AuthUser> {
-  const ctx = await requireAuthContext(request);
-  return ctx.user;
-}
+export const { getAuthContext, requireAuthContext, getUser, requireUser } =
+  createAuthHelpers({ getAuth });

--- a/examples/team-blog-after/app/cfast.server.ts
+++ b/examples/team-blog-after/app/cfast.server.ts
@@ -33,10 +33,11 @@ export const appDb = createAppDb({
   cache: false,
 });
 
-// Inline db plugin — exposes both permission-aware client and raw Drizzle
-type AuthProvides = { auth: { user: AuthUser | null; grants: Grant[] } };
-const dbPlugin = definePlugin<AuthProvides>()({
-  name: "db",
+// db plugin — uses `requires` inference (no curried form) to depend on authPlugin.
+// Exposes both the permission-aware client and raw Drizzle.
+const dbPlugin = definePlugin({
+  name: "db" as const,
+  requires: [authPlugin],
   setup(ctx) {
     const client = appDb(
       ctx.auth.grants,


### PR DESCRIPTION
## Summary
- Replace hand-rolled auth helpers (~25 lines) with `createAuthHelpers()` from `@cfast/auth/helpers`
- Replace `createAdminAuth` (from `@cfast/auth`) with `createAdminAuthAdapter` (from `@cfast/admin`) — keeps admin imports self-contained in one package
- Replace curried `definePlugin<T>()({...})` with modern `requires: [authPlugin]` inference form — no explicit type token needed

Items 4-6 from the plan (remove `as unknown as` casts, `toJSON()`, `TransactionResult`) were checked but have no occurrences in this example.

## Test plan
- [x] `pnpm turbo build --filter=team-blog-after` passes
- [x] `pnpm turbo typecheck --filter=team-blog-after` passes
- [ ] Smoke-test admin panel, auth flow, and post CRUD in local dev

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)