### PR TITLE
feat: unified permission UI -- cfastJson, useCfastLoader, ActionButton href/input

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,6 +76,10 @@ These principles are non-negotiable — all code, examples, and tests must follo
 | Custom file upload endpoints | `@cfast/storage` with schema-defined file types |
 | `compose` with no data dependencies | `composeSequential(ops)` |
 | `composed.client` from `.server` import | `clientDescriptor()` from `@cfast/actions/client` |
+| Manual `can()` + boolean passing in loaders | `cfastJson(grants, schema, data)` from `@cfast/actions` |
+| `useLoaderData` + manual `_can` checks | `useCfastLoader()` from `@cfast/actions/client` |
+| `{canX && <Button component={Link}>}` | `<ActionButton action={x.canAdd()} href={...}>` |
+| `<Form> + <input type="hidden">` for deletes | `<ActionButton action={x.canDelete()} input={{...}}>` |
 
 ## React Router Server/Client Boundary
 

--- a/docs/website/src/content/docs/guides/actions.mdx
+++ b/docs/website/src/content/docs/guides/actions.mdx
@@ -204,3 +204,78 @@ const actions = useActions(client);
 
 This replaces the pattern of importing `composed.client` from a `.server` module, which breaks React Router's server/client code splitting. See [the server/client boundary notes](/cfast/guides/actions/#dual-input-formats) for why this matters.
 
+### `cfastJson()` and `useCfastLoader()`
+
+For routes that use `@cfast/db` queries with `_can` annotations, `cfastJson()` and `useCfastLoader()` provide a higher-level abstraction that eliminates manual `can()` calls and permission boolean prop-drilling.
+
+**Server (loader):**
+
+```typescript
+import { cfastJson } from "@cfast/actions";
+import * as schema from "../db/schema";
+
+export const loader = async ({ context }) => {
+  const documents = await db.query(documentsTable).findMany().run();
+  return cfastJson(ctx.auth.grants, schema, { documents });
+};
+```
+
+`cfastJson()` embeds `_tablePerms` (a map of table-level CRUD permissions) into the response and serializes dates. Each array whose key matches a schema table is annotated so the client hook can resolve `canAdd()`.
+
+**Client (component):**
+
+```tsx
+import { useCfastLoader } from "@cfast/actions/client";
+import { ActionButton } from "@cfast/joy";
+
+function DocumentList() {
+  const { documents } = useCfastLoader<typeof loader>();
+
+  return (
+    <>
+      <ActionButton action={documents.canAdd()} href="/documents/new">
+        New Document
+      </ActionButton>
+      {documents.map((doc) => (
+        <div key={doc.id}>
+          <span>{doc.title}</span>
+          <ActionButton
+            action={doc.canEdit()}
+            href={`/documents/${doc.id}/edit`}
+            whenForbidden="hide"
+          >
+            Edit
+          </ActionButton>
+          <ActionButton
+            action={doc.canDelete()}
+            input={{ _action: "delete", id: doc.id }}
+            whenForbidden="hide"
+          >
+            Delete
+          </ActionButton>
+        </div>
+      ))}
+    </>
+  );
+}
+```
+
+Row fields are directly accessible (`doc.title`), and permission methods (`doc.canEdit()`) return `ActionHookResult`. No `.data` wrapper needed.
+
+### ActionButton `href` and `input` props
+
+`ActionButton` now supports two additional props:
+
+- **`href`**: Renders as a permission-gated link instead of a form button. When the action is not permitted, the link is disabled or hidden per `whenForbidden`.
+- **`input`**: Submits a form with the provided key-value pairs as hidden fields via a fetcher. Eliminates manual `<Form>` + `<input type="hidden">` boilerplate.
+
+```tsx
+// Navigation link
+<ActionButton action={posts.canAdd()} href="/posts/new">New Post</ActionButton>
+
+// Form data submission
+<ActionButton action={post.canDelete()} input={{ _action: "deletePost", id: post.id }}>
+  Delete
+</ActionButton>
+```
+

--- a/docs/website/src/content/docs/guides/permissions.mdx
+++ b/docs/website/src/content/docs/guides/permissions.mdx
@@ -235,9 +235,43 @@ The `read` action is always `true` on returned rows because the permission WHERE
 
 `can(grants, "update", posts)` answers "does the user have **any** update grant on posts?" -- a structural check. `post._can.update` answers "does the grant's WHERE clause match **this row**?" -- a row-level truth.
 
+#### `resolveTablePermissions()`
+
+For batch table-level checks, `resolveTablePermissions()` evaluates all four CRUD actions for every table in the schema at once:
+
+```typescript
+import { resolveTablePermissions } from "@cfast/permissions";
+import * as schema from "../db/schema";
+
+const perms = resolveTablePermissions(grants, schema);
+// { posts: { read: true, create: true, update: false, delete: false }, ... }
+```
+
+This is used internally by `cfastJson()` from `@cfast/actions` to embed table permissions in loader data. You rarely need to call it directly.
+
 #### UI Patterns
 
-Use `_can` to conditionally render actions per row:
+**With `useCfastLoader()` (recommended)** -- wraps `_can` into permission methods:
+
+```tsx
+import { useCfastLoader } from "@cfast/actions/client";
+import { ActionButton } from "@cfast/joy";
+
+function PostList() {
+  const { posts } = useCfastLoader<typeof loader>();
+  return posts.map((post) => (
+    <tr key={post.id}>
+      <td>{post.title}</td>
+      <td>
+        <ActionButton action={post.canEdit()} href={`/posts/${post.id}/edit`} whenForbidden="hide">Edit</ActionButton>
+        <ActionButton action={post.canDelete()} input={{ _action: "delete", id: post.id }} whenForbidden="hide">Delete</ActionButton>
+      </td>
+    </tr>
+  ));
+}
+```
+
+**Manual `_can` checks** -- use `_can` to conditionally render actions per row:
 
 ```tsx
 function PostRow({ post }: { post: WithCan<Post> }) {

--- a/examples/team-blog-after/app/routes/home.tsx
+++ b/examples/team-blog-after/app/routes/home.tsx
@@ -1,11 +1,14 @@
-import { useLoaderData, Link } from "react-router";
+import { Link } from "react-router";
 import Container from "@mui/joy/Container";
 import Stack from "@mui/joy/Stack";
 import Typography from "@mui/joy/Typography";
-import Button from "@mui/joy/Button";
 import { can } from "@cfast/permissions";
+import { cfastJson } from "@cfast/actions";
+import { useCfastLoader } from "@cfast/actions/client";
+import { ActionButton } from "@cfast/joy";
 import { app } from "~/cfast.server";
 import { posts, users } from "~/db/schema";
+import * as schema from "~/db/schema";
 import { eq, desc, count } from "drizzle-orm";
 import { Header } from "~/components/Header";
 import { PostCard } from "~/components/PostCard";
@@ -61,18 +64,20 @@ export const loader = app.loader(async (ctx, { request }) => {
   }));
 
   return {
-    posts: formattedPosts,
+    ...cfastJson(grants, schema, { posts: formattedPosts }),
     total,
     page,
     limit,
     user,
+    // Server-side booleans still needed for Header (which doesn't use useCfastLoader)
     canCreatePost: can(grants, "create", posts),
     canAdmin: can(grants, "manage", "all"),
   };
 });
 
 export default function Home() {
-  const { posts: postList, total, page, limit, user, canCreatePost, canAdmin } = useLoaderData<typeof loader>();
+  const data = useCfastLoader<typeof loader>();
+  const { posts: postList, total, page, limit, user, canCreatePost, canAdmin } = data;
   const totalPages = Math.ceil(total / limit);
 
   return (
@@ -82,9 +87,12 @@ export default function Home() {
         <Stack direction="row" justifyContent="space-between" alignItems="center" sx={{ mb: 3 }}>
           <Typography level="h2">Latest Posts</Typography>
           {user && canCreatePost && (
-            <Button component={Link} to="/posts/new">
+            <ActionButton
+              action={{ permitted: canCreatePost, invisible: false, reason: null, submit: () => {}, pending: false, data: undefined, error: undefined }}
+              href="/posts/new"
+            >
               New Post
-            </Button>
+            </ActionButton>
           )}
         </Stack>
 

--- a/examples/team-blog-after/app/routes/posts.$slug.tsx
+++ b/examples/team-blog-after/app/routes/posts.$slug.tsx
@@ -1,4 +1,4 @@
-import { useLoaderData, useActionData, useFetcher } from "react-router";
+import { useActionData, useFetcher } from "react-router";
 import { useState, useEffect, useCallback, useRef } from "react";
 import Container from "@mui/joy/Container";
 import Stack from "@mui/joy/Stack";
@@ -11,12 +11,14 @@ import Box from "@mui/joy/Box";
 import Avatar from "@mui/joy/Avatar";
 import Divider from "@mui/joy/Divider";
 import Chip from "@mui/joy/Chip";
-import { useActions, clientDescriptor } from "@cfast/actions/client";
+import { useActions, clientDescriptor, useCfastLoader } from "@cfast/actions/client";
 import { ActionForm } from "@cfast/actions/client";
 import { ActionButton } from "@cfast/joy";
+import { cfastJson } from "@cfast/actions";
 import { can } from "@cfast/permissions";
 import { app } from "~/cfast.server";
 import { posts, users, comments } from "~/db/schema";
+import * as schema from "~/db/schema";
 import { eq, desc, and, lt } from "drizzle-orm";
 import { Header } from "~/components/Header";
 import { CommentItem } from "~/components/CommentItem";
@@ -133,11 +135,11 @@ export const loader = app.loader(async (ctx, { params, request }) => {
   const canAdmin = can(grants, "manage", "all");
 
   return {
+    ...cfastJson(grants, schema, { comments: formattedComments }),
     post,
     author: author
       ? { id: author.id, name: author.name, avatarUrl: author.avatarUrl }
       : { id: post.authorId, name: "Unknown", avatarUrl: null },
-    comments: formattedComments,
     nextCursor,
     user,
     canEdit,
@@ -215,10 +217,18 @@ function useInfiniteComments(
 }
 
 export default function PostDetail() {
+  const data = useCfastLoader<typeof loader>();
   const {
-    post, author, comments: initialComments, nextCursor, user,
+    post, author, nextCursor, user,
     canEdit, canDelete, canPublish, canCreatePost, canAdmin,
-  } = useLoaderData<typeof loader>();
+  } = data;
+  const initialComments = data.comments as unknown as Array<{
+    id: string;
+    content: string;
+    createdAt: Date;
+    _can: Record<string, boolean>;
+    author: { id: string; name: string; avatarUrl: string | null };
+  }>;
   const actionData = useActionData<typeof action>() as
     | { success: boolean; action: string }
     | { error: string; action: string }
@@ -278,11 +288,15 @@ export default function PostDetail() {
 
         {/* Action Buttons */}
         <Stack direction="row" spacing={1} sx={{ mb: 4 }}>
-          {canEdit && (
-            <Button component={Link} to={`/posts/${post.slug}/edit`} variant="outlined" size="sm">
-              Edit
-            </Button>
-          )}
+          <ActionButton
+            action={{ permitted: canEdit, invisible: false, reason: null, submit: () => {}, pending: false, data: undefined, error: undefined }}
+            href={`/posts/${post.slug}/edit`}
+            whenForbidden="hide"
+            variant="outlined"
+            size="sm"
+          >
+            Edit
+          </ActionButton>
           {canPublish && !post.published && (
             <ActionButton
               action={actions.publishPost({ postId: post.id, title: post.title, slug: post.slug, authorId: post.authorId })}

--- a/examples/team-blog-after/app/routes/profile.tsx
+++ b/examples/team-blog-after/app/routes/profile.tsx
@@ -1,4 +1,5 @@
-import { useLoaderData, useActionData, Form } from "react-router";
+import { useActionData, Form } from "react-router";
+import { useCfastLoader } from "@cfast/actions/client";
 import { useState } from "react";
 import Container from "@mui/joy/Container";
 import Stack from "@mui/joy/Stack";
@@ -121,7 +122,7 @@ export const action = app.action(async (ctx, { request }) => {
 });
 
 export default function Profile() {
-  const { user, passkeys: userPasskeys, canCreatePost, canAdmin } = useLoaderData<typeof loader>();
+  const { user, passkeys: userPasskeys, canCreatePost, canAdmin } = useCfastLoader<typeof loader>();
   const actionData = useActionData<typeof action>();
   const { registerPasskey, deletePasskey } = useAuth();
   const [name, setName] = useState(user.name);

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1392,11 +1392,41 @@ type ClientDescriptor<TNames extends readonly string[] = readonly string[]> = {
 };
 ```
 
+### `cfastJson(grants, schema, data)` (server)
+
+Wraps loader data with table-level permission metadata and serializes dates. Replaces manual `can()` per table + `toJSON()`.
+
+```typescript
+import { cfastJson } from "@cfast/actions";
+import * as schema from "../db/schema";
+
+return cfastJson(ctx.auth.grants, schema, { documents });
+// Returns { documents, _tablePerms: { documents: { read, create, update, delete } } }
+```
+
+### `useCfastLoader<T>()` (client)
+
+Replaces `useLoaderData()` for routes using `cfastJson()`. Wraps `_can` arrays/objects with permission methods.
+
+```typescript
+import { useCfastLoader } from "@cfast/actions/client";
+
+const { documents } = useCfastLoader<typeof loader>();
+documents.canAdd()          // ActionHookResult (from _tablePerms)
+documents[0].title          // direct field access
+documents[0].canEdit()      // ActionHookResult (from _can.update)
+documents[0].canDelete()    // ActionHookResult (from _can.delete)
+```
+
+### `resolveTablePermissions(grants, schema)` (from @cfast/permissions)
+
+Returns `Record<tableName, Record<CrudAction, boolean>>` for every table in the schema. Used internally by `cfastJson()`.
+
 ### Exports
 
 ```
-@cfast/actions         -> createActions, checkPermissionStatus
-@cfast/actions/client  -> useActions, clientDescriptor, ActionForm
+@cfast/actions         -> createActions, checkPermissionStatus, cfastJson
+@cfast/actions/client  -> useActions, useCfastLoader, clientDescriptor, ActionForm
 ```
 
 ---
@@ -1827,13 +1857,28 @@ Shows avatar, name, email, role badge, impersonation indicator, sign out.
 #### `<ActionButton>`
 
 ```typescript
+// Form submission (default)
 <ActionButton
   action={publishPost}
-  input={{ postId }}
   whenForbidden="disable"    // "hide" | "disable" | "show"
   confirmation="Publish this post?"
 >
   Publish
+</ActionButton>
+
+// Navigation link (permission-gated, renders as link instead of form button)
+<ActionButton action={documents.canAdd()} href="/documents/new">
+  New Document
+</ActionButton>
+
+// Form data via input prop (submits hidden fields via fetcher)
+<ActionButton
+  action={recipe.canDelete()}
+  input={{ _action: "deleteRecipe", id: recipe.id }}
+  whenForbidden="hide"
+  confirmation="Delete this recipe?"
+>
+  Delete
 </ActionButton>
 ```
 

--- a/llms.txt
+++ b/llms.txt
@@ -98,7 +98,18 @@ export async function loader({ request, context }) {
   return { posts, canCreate }; // run() params optional
 }
 
-// 3. Permission-aware UI (client)
+// 2b. Or use cfastJson() for automatic table permissions + date serialization
+import { cfastJson } from "@cfast/actions";
+import * as schema from "./db/schema";
+
+export async function loader({ request, context }) {
+  const posts = await db.query(postsTable).findMany().run();
+  return cfastJson(ctx.auth.grants, schema, { posts });
+  // Embeds _tablePerms for every table, serializes dates, annotates arrays
+}
+
+// 3. Permission-aware UI (client) — two approaches
+// Approach A: useActions for action-level permissions
 import { useActions } from "@cfast/actions/client";
 
 function PostActions({ postId }) {
@@ -109,6 +120,27 @@ function PostActions({ postId }) {
     <button onClick={remove.submit} disabled={!remove.permitted}>
       Delete
     </button>
+  );
+}
+
+// Approach B: useCfastLoader for row/table-level permissions (with cfastJson)
+import { useCfastLoader } from "@cfast/actions/client";
+import { ActionButton } from "@cfast/joy";
+
+function PostList() {
+  const { posts } = useCfastLoader<typeof loader>();
+  // posts[0].title      — direct field access
+  // posts[0].canEdit()  — ActionHookResult from _can
+  // posts.canAdd()      — ActionHookResult from _tablePerms
+  return (
+    <>
+      <ActionButton action={posts.canAdd()} href="/posts/new">New Post</ActionButton>
+      {posts.map(post => (
+        <ActionButton action={post.canDelete()} input={{ _action: "delete", id: post.id }}>
+          Delete {post.title}
+        </ActionButton>
+      ))}
+    </>
   );
 }
 ```

--- a/packages/actions/llms.txt
+++ b/packages/actions/llms.txt
@@ -16,6 +16,21 @@ Use this package when you need React Router route actions that automatically che
 
 ### Server (`@cfast/actions`)
 
+#### `cfastJson(grants, schema, data)`
+Server-side loader helper that wraps data with table-level permission metadata and serializes dates. Replaces the manual pattern of calling `can()` per table and `toJSON()` separately.
+
+```typescript
+import { cfastJson } from "@cfast/actions";
+import * as schema from "../db/schema";
+
+export async function loader({ context }) {
+  const documents = await db.query(documentsTable).findMany().run();
+  return cfastJson(ctx.auth.grants, schema, { documents });
+}
+```
+
+Returns the data with `_tablePerms` embedded and dates serialized. Arrays whose keys match schema table names are annotated with a non-enumerable `_tableName` property so `useCfastLoader` can resolve `canAdd()` for the correct table.
+
 ```typescript
 function createActions<TUser>(config: ActionsConfig<TUser>): {
   createAction: <TInput, TResult>(
@@ -111,6 +126,36 @@ type ActionFormProps = Omit<ComponentProps<typeof Form>, "children" | "action"> 
   children: ReactNode;
 };
 ```
+
+#### `useCfastLoader<T>()`
+Client hook that replaces `useLoaderData()` for routes using `cfastJson()`. Returns the same data but wraps arrays and objects that have `_can` with permission helper methods.
+
+```typescript
+import { useCfastLoader } from "@cfast/actions/client";
+
+const { documents } = useCfastLoader<typeof loader>();
+
+// Collection-level: "can I add to this table?"
+documents.canAdd()          // -> ActionHookResult
+
+// Row fields accessible directly (no .data wrapper)
+documents[0].title          // "Hello World"
+
+// Row-level: "can I edit THIS item?"
+documents[0].canEdit()      // -> ActionHookResult
+documents[0].canDelete()    // -> ActionHookResult
+
+// Single items work too
+const { document } = useCfastLoader<typeof loader>();
+document.canEdit()          // -> ActionHookResult
+```
+
+Wrapping rules:
+- Array where items have `_can` -> collection: array + `canAdd()`, each item has `canEdit()`, `canDelete()`, `canRead()`, `canCreate()`
+- Object with `_can` -> item: row properties directly accessible + `can*()` methods
+- Otherwise -> pass through unchanged
+
+All `can*()` methods return `ActionHookResult` with `permitted`, `invisible`, `reason`, `submit` (no-op), `pending` (false), `data`, `error`.
 
 `ActionForm` is a form wrapper that auto-injects hidden fields from an action descriptor object. Replaces manual `<input type="hidden">` patterns when using `composeActions`.
 

--- a/packages/actions/package.json
+++ b/packages/actions/package.json
@@ -46,7 +46,7 @@
   },
   "peerDependencies": {
     "@cfast/db": ">=0.3.0 <0.5.0",
-    "@cfast/permissions": ">=0.3.0 <0.6.0",
+    "@cfast/permissions": ">=0.3.0 <0.7.0",
     "react": "^19.0.0",
     "react-router": "^7.0.0"
   },

--- a/packages/actions/src/__tests__/cfast-json.test.ts
+++ b/packages/actions/src/__tests__/cfast-json.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect } from "vitest";
+import { cfastJson } from "../cfast-json";
+import { definePermissions, resolveGrants, grant } from "@cfast/permissions";
+import type { DrizzleTable } from "@cfast/permissions";
+
+const DRIZZLE_NAME = Symbol.for("drizzle:Name");
+const posts: DrizzleTable = { [DRIZZLE_NAME]: "posts" };
+const comments: DrizzleTable = { [DRIZZLE_NAME]: "comments" };
+
+const schema = { posts, comments } as Record<string, DrizzleTable>;
+
+const permissions = definePermissions({
+  roles: ["reader", "author", "admin"] as const,
+  hierarchy: { author: ["reader"], admin: ["author"] },
+  grants: {
+    reader: [grant("read", posts), grant("read", comments)],
+    author: [grant("create", posts), grant("create", comments)],
+    admin: [grant("manage", "all")],
+  },
+});
+
+function grantsFor(role: string) {
+  return resolveGrants(permissions, [role]);
+}
+
+describe("cfastJson", () => {
+  it("embeds _tablePerms from resolveTablePermissions", () => {
+    const result = cfastJson(grantsFor("reader"), schema, { posts: [] });
+
+    expect(result._tablePerms).toBeDefined();
+    expect(result._tablePerms.posts).toEqual({
+      read: true,
+      create: false,
+      update: false,
+      delete: false,
+    });
+    expect(result._tablePerms.comments).toEqual({
+      read: true,
+      create: false,
+      update: false,
+      delete: false,
+    });
+  });
+
+  it("serializes Date values to ISO strings", () => {
+    const date = new Date("2025-01-15T10:30:00.000Z");
+    const result = cfastJson(grantsFor("reader"), schema, {
+      posts: [{ id: "1", title: "Hello", createdAt: date }],
+    });
+
+    expect((result.posts as unknown[])[0]).toEqual(
+      expect.objectContaining({
+        id: "1",
+        title: "Hello",
+        createdAt: "2025-01-15T10:30:00.000Z",
+      }),
+    );
+  });
+
+  it("passes through non-Date fields unchanged", () => {
+    const result = cfastJson(grantsFor("reader"), schema, {
+      count: 42,
+      title: "hello",
+      active: true,
+    });
+
+    expect(result.count).toBe(42);
+    expect(result.title).toBe("hello");
+    expect(result.active).toBe(true);
+  });
+
+  it("annotates arrays with a non-enumerable _tableName when key matches schema", () => {
+    const result = cfastJson(grantsFor("reader"), schema, {
+      posts: [{ id: "1" }],
+    });
+
+    // Non-enumerable: should not appear in JSON or Object.keys
+    expect(Object.keys(result.posts as unknown[])).not.toContain("_tableName");
+    // But accessible directly
+    expect((result.posts as unknown as { _tableName: string })._tableName).toBe("posts");
+  });
+
+  it("does not annotate arrays whose key does not match any schema table", () => {
+    const result = cfastJson(grantsFor("reader"), schema, {
+      tags: ["a", "b"],
+    });
+
+    expect((result.tags as unknown as { _tableName?: string })._tableName).toBeUndefined();
+  });
+
+  it("admin gets full CRUD on all tables", () => {
+    const result = cfastJson(grantsFor("admin"), schema, {});
+
+    expect(result._tablePerms.posts).toEqual({
+      read: true,
+      create: true,
+      update: true,
+      delete: true,
+    });
+  });
+
+  it("preserves original data fields alongside _tablePerms", () => {
+    const result = cfastJson(grantsFor("reader"), schema, {
+      posts: [{ id: "1" }],
+      total: 1,
+    });
+
+    expect(result.total).toBe(1);
+    expect((result.posts as unknown[])[0]).toEqual(expect.objectContaining({ id: "1" }));
+    expect(result._tablePerms).toBeDefined();
+  });
+});

--- a/packages/actions/src/__tests__/use-cfast-loader.test.ts
+++ b/packages/actions/src/__tests__/use-cfast-loader.test.ts
@@ -7,6 +7,15 @@ vi.mock("react-router", () => ({
   useLoaderData: () => mockLoaderData,
 }));
 
+// Mock useMemo to just execute the factory immediately (no React context needed)
+vi.mock("react", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react")>();
+  return {
+    ...actual,
+    useMemo: <T>(factory: () => T, _deps: unknown[]): T => factory(),
+  };
+});
+
 // Import after mocks are set up
 const { useCfastLoader } = await import("../client/use-cfast-loader.js");
 

--- a/packages/actions/src/__tests__/use-cfast-loader.test.ts
+++ b/packages/actions/src/__tests__/use-cfast-loader.test.ts
@@ -1,0 +1,262 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock state
+let mockLoaderData: Record<string, unknown> = {};
+
+vi.mock("react-router", () => ({
+  useLoaderData: () => mockLoaderData,
+}));
+
+// Import after mocks are set up
+const { useCfastLoader } = await import("../client/use-cfast-loader.js");
+
+describe("useCfastLoader", () => {
+  beforeEach(() => {
+    mockLoaderData = {};
+  });
+
+  it("passes through plain fields unchanged", () => {
+    mockLoaderData = {
+      title: "hello",
+      count: 42,
+      active: true,
+    };
+
+    const result = useCfastLoader();
+    expect(result.title).toBe("hello");
+    expect(result.count).toBe(42);
+    expect(result.active).toBe(true);
+  });
+
+  it("does not expose _tablePerms on the result", () => {
+    mockLoaderData = {
+      _tablePerms: { posts: { read: true, create: true, update: true, delete: true } },
+      title: "hello",
+    };
+
+    const result = useCfastLoader();
+    expect(result._tablePerms).toBeUndefined();
+    expect(result.title).toBe("hello");
+  });
+
+  describe("item wrapping (object with _can)", () => {
+    it("wraps an object with _can into an item with can*() methods", () => {
+      mockLoaderData = {
+        post: {
+          id: "1",
+          title: "Hello World",
+          _can: { read: true, create: false, update: true, delete: false },
+        },
+        _tablePerms: {},
+      };
+
+      const result = useCfastLoader();
+      const post = result.post as Record<string, unknown>;
+
+      // Row fields accessible directly
+      expect(post.id).toBe("1");
+      expect(post.title).toBe("Hello World");
+
+      // Permission methods
+      expect(typeof post.canEdit).toBe("function");
+      expect(typeof post.canDelete).toBe("function");
+      expect(typeof post.canRead).toBe("function");
+      expect(typeof post.canCreate).toBe("function");
+
+      // Returns ActionHookResult
+      const editResult = (post.canEdit as () => unknown)();
+      expect(editResult).toEqual(
+        expect.objectContaining({
+          permitted: true,
+          invisible: false,
+          reason: null,
+          pending: false,
+        }),
+      );
+
+      const deleteResult = (post.canDelete as () => unknown)();
+      expect(deleteResult).toEqual(
+        expect.objectContaining({ permitted: false }),
+      );
+    });
+
+    it("can*() methods are non-enumerable", () => {
+      mockLoaderData = {
+        post: {
+          id: "1",
+          _can: { read: true, create: true, update: true, delete: true },
+        },
+        _tablePerms: {},
+      };
+
+      const result = useCfastLoader();
+      const post = result.post as Record<string, unknown>;
+      const keys = Object.keys(post);
+
+      expect(keys).toContain("id");
+      expect(keys).not.toContain("canEdit");
+      expect(keys).not.toContain("canDelete");
+      expect(keys).not.toContain("canRead");
+      expect(keys).not.toContain("canCreate");
+      expect(keys).not.toContain("_can");
+    });
+  });
+
+  describe("collection wrapping (array with _can items)", () => {
+    it("wraps each item with can*() methods", () => {
+      const arr = [
+        { id: "1", title: "First", _can: { read: true, create: false, update: true, delete: false } },
+        { id: "2", title: "Second", _can: { read: true, create: false, update: false, delete: true } },
+      ];
+
+      // Simulate cfastJson _tableName annotation
+      Object.defineProperty(arr, "_tableName", {
+        value: "posts",
+        enumerable: false,
+      });
+
+      mockLoaderData = {
+        posts: arr,
+        _tablePerms: {
+          posts: { read: true, create: true, update: false, delete: false },
+        },
+      };
+
+      const result = useCfastLoader();
+      const posts = result.posts as unknown[];
+
+      // Array works normally
+      expect(posts.length).toBe(2);
+      expect((posts[0] as Record<string, unknown>).title).toBe("First");
+      expect((posts[1] as Record<string, unknown>).title).toBe("Second");
+
+      // Each item has can*() methods
+      const first = posts[0] as Record<string, unknown>;
+      expect(typeof first.canEdit).toBe("function");
+      const editResult = (first.canEdit as () => unknown)();
+      expect(editResult).toEqual(expect.objectContaining({ permitted: true }));
+
+      const second = posts[1] as Record<string, unknown>;
+      const deleteResult = (second.canDelete as () => unknown)();
+      expect(deleteResult).toEqual(expect.objectContaining({ permitted: true }));
+    });
+
+    it("adds canAdd() method from _tablePerms", () => {
+      const arr = [
+        { id: "1", _can: { read: true, create: false, update: false, delete: false } },
+      ];
+
+      Object.defineProperty(arr, "_tableName", {
+        value: "posts",
+        enumerable: false,
+      });
+
+      mockLoaderData = {
+        posts: arr,
+        _tablePerms: {
+          posts: { read: true, create: true, update: false, delete: false },
+        },
+      };
+
+      const result = useCfastLoader();
+      const posts = result.posts as unknown as { canAdd: () => unknown };
+
+      expect(typeof posts.canAdd).toBe("function");
+      const addResult = posts.canAdd();
+      expect(addResult).toEqual(expect.objectContaining({ permitted: true }));
+    });
+
+    it("canAdd() returns false when create is not permitted", () => {
+      const arr = [
+        { id: "1", _can: { read: true, create: false, update: false, delete: false } },
+      ];
+
+      Object.defineProperty(arr, "_tableName", {
+        value: "posts",
+        enumerable: false,
+      });
+
+      mockLoaderData = {
+        posts: arr,
+        _tablePerms: {
+          posts: { read: true, create: false, update: false, delete: false },
+        },
+      };
+
+      const result = useCfastLoader();
+      const posts = result.posts as unknown as { canAdd: () => { permitted: boolean } };
+
+      expect(posts.canAdd().permitted).toBe(false);
+    });
+
+    it("canAdd() is non-enumerable", () => {
+      const arr = [
+        { id: "1", _can: { read: true, create: false, update: false, delete: false } },
+      ];
+
+      Object.defineProperty(arr, "_tableName", {
+        value: "posts",
+        enumerable: false,
+      });
+
+      mockLoaderData = {
+        posts: arr,
+        _tablePerms: {
+          posts: { read: true, create: true, update: false, delete: false },
+        },
+      };
+
+      const result = useCfastLoader();
+      const posts = result.posts as unknown[];
+      const keys = Object.keys(posts);
+      expect(keys).not.toContain("canAdd");
+    });
+  });
+
+  describe("passthrough for arrays without _can", () => {
+    it("does not wrap arrays of primitives", () => {
+      mockLoaderData = {
+        tags: ["a", "b", "c"],
+        _tablePerms: {},
+      };
+
+      const result = useCfastLoader();
+      expect(result.tags).toEqual(["a", "b", "c"]);
+      expect((result.tags as unknown as { canAdd?: unknown }).canAdd).toBeUndefined();
+    });
+
+    it("does not wrap arrays of objects without _can", () => {
+      mockLoaderData = {
+        items: [{ id: "1" }, { id: "2" }],
+        _tablePerms: {},
+      };
+
+      const result = useCfastLoader();
+      const items = result.items as unknown[];
+      expect(items.length).toBe(2);
+      expect((items[0] as Record<string, unknown>).canEdit).toBeUndefined();
+    });
+  });
+
+  describe("empty collections", () => {
+    it("handles empty arrays gracefully", () => {
+      const arr: unknown[] = [];
+      Object.defineProperty(arr, "_tableName", {
+        value: "posts",
+        enumerable: false,
+      });
+
+      mockLoaderData = {
+        posts: arr,
+        _tablePerms: {
+          posts: { read: true, create: true, update: false, delete: false },
+        },
+      };
+
+      const result = useCfastLoader();
+      const posts = result.posts as unknown[];
+      expect(posts.length).toBe(0);
+      // Empty arrays don't have _can items, so they pass through
+    });
+  });
+});

--- a/packages/actions/src/cfast-json.ts
+++ b/packages/actions/src/cfast-json.ts
@@ -1,0 +1,97 @@
+import type { Grant, SchemaMap, CrudAction } from "@cfast/permissions";
+import { resolveTablePermissions } from "@cfast/permissions";
+import { toJSON } from "@cfast/db";
+
+/**
+ * Server-side loader helper that wraps data with table-level permission
+ * metadata and serializes dates.
+ *
+ * Replaces the manual pattern of calling `can()` per table and `toJSON()`
+ * separately. The returned object contains:
+ *
+ * - All fields from `data`, with Dates converted to ISO strings.
+ * - `_tablePerms`: a `Record<tableName, Record<CrudAction, boolean>>` map
+ *   covering every table in the schema.
+ * - Each array value in `data` is annotated with a non-enumerable
+ *   `_tableName` property matching the first table whose SQL name appears
+ *   as the data key. This allows the client-side `useCfastLoader` hook to
+ *   look up `canAdd()` for the correct table.
+ *
+ * @param grants - The user's resolved permission grants.
+ * @param schema - A schema map (e.g. `import * as schema from "./schema"`).
+ * @param data - The loader data to wrap.
+ * @returns A serializable object with `_tablePerms` embedded.
+ *
+ * @example
+ * ```ts
+ * import { cfastJson } from "@cfast/actions";
+ * import * as schema from "../db/schema";
+ *
+ * export async function loader({ context }) {
+ *   const documents = await db.query(documentsTable).findMany().run();
+ *   return cfastJson(ctx.auth.grants, schema, { documents });
+ * }
+ * ```
+ */
+export function cfastJson<TData extends Record<string, unknown>>(
+  grants: Grant[],
+  schema: SchemaMap,
+  data: TData,
+): TData & { _tablePerms: Record<string, Record<CrudAction, boolean>> } {
+  const tablePerms = resolveTablePermissions(grants, schema);
+
+  // Serialize dates via toJSON, then re-attach _tablePerms
+  const serialized = toJSON(data) as Record<string, unknown>;
+
+  // Build a reverse lookup: JS key name -> SQL table name
+  // E.g. { postsRelations: ... } or { posts: "posts", documentVersions: "document_versions" }
+  const keyToTableName: Record<string, string> = {};
+  for (const [jsKey, table] of Object.entries(schema)) {
+    const DRIZZLE_NAME_SYMBOL = Symbol.for("drizzle:Name");
+    if (typeof table === "object" && table !== null) {
+      const name: unknown = Reflect.get(table, DRIZZLE_NAME_SYMBOL);
+      if (typeof name === "string") {
+        // Use both the JS key (e.g. "posts") and the SQL name (e.g. "posts")
+        // Also store the lowercase JS key for matching
+        keyToTableName[jsKey] = name;
+      }
+    }
+  }
+
+  // Annotate arrays in the serialized data with _tableName so the client
+  // hook can figure out which table a collection corresponds to.
+  for (const [key, value] of Object.entries(serialized)) {
+    if (Array.isArray(value)) {
+      // Try to find a matching table name for this data key.
+      // Convention: the data key matches the JS schema key or SQL table name.
+      let tableName: string | undefined;
+
+      // Direct match: key in schema map
+      if (keyToTableName[key]) {
+        tableName = keyToTableName[key];
+      } else {
+        // Try matching against SQL table names
+        for (const sqlName of Object.values(keyToTableName)) {
+          if (sqlName === key) {
+            tableName = sqlName;
+            break;
+          }
+        }
+      }
+
+      if (tableName) {
+        Object.defineProperty(value, "_tableName", {
+          value: tableName,
+          enumerable: false,
+          writable: false,
+          configurable: false,
+        });
+      }
+    }
+  }
+
+  return {
+    ...serialized,
+    _tablePerms: tablePerms,
+  } as TData & { _tablePerms: Record<string, Record<CrudAction, boolean>> };
+}

--- a/packages/actions/src/client.ts
+++ b/packages/actions/src/client.ts
@@ -1,4 +1,5 @@
 export { useActions, clientDescriptor } from "./client/use-actions.js";
+export { useCfastLoader } from "./client/use-cfast-loader.js";
 export { ActionForm } from "./client/action-form.js";
 export type { ActionHookResult } from "./client/use-actions.js";
 export type { ClientDescriptor } from "./types.js";

--- a/packages/actions/src/client/use-cfast-loader.ts
+++ b/packages/actions/src/client/use-cfast-loader.ts
@@ -1,0 +1,228 @@
+import { useLoaderData } from "react-router";
+import type { ActionHookResult } from "./use-actions.js";
+
+/**
+ * The four CRUD actions used in `_can` annotations and `_tablePerms`.
+ * Matches CrudAction from @cfast/permissions.
+ */
+type CrudAction = "read" | "create" | "update" | "delete";
+
+/**
+ * Creates an {@link ActionHookResult} from a boolean permission value.
+ *
+ * Since these are read-only permission checks (not tied to a fetcher),
+ * `submit` is a no-op, `pending` is false, and `data`/`error` are undefined.
+ */
+function makeResult(permitted: boolean): ActionHookResult {
+  return {
+    permitted,
+    invisible: false,
+    reason: null,
+    submit: () => {},
+    pending: false,
+    data: undefined,
+    error: undefined,
+  };
+}
+
+/**
+ * Wraps a single row object that has `_can` with permission helper methods.
+ *
+ * The returned object spreads all original row properties AND adds
+ * `canRead()`, `canCreate()`, `canEdit()`, `canDelete()` methods.
+ * Row fields are directly accessible (no `.data` wrapper).
+ *
+ * Uses `Object.create` with property descriptors so the `can*()` methods
+ * coexist with row properties without conflicts.
+ */
+function wrapItem<T extends Record<string, unknown>>(
+  item: T,
+): T & {
+  canRead: () => ActionHookResult;
+  canCreate: () => ActionHookResult;
+  canEdit: () => ActionHookResult;
+  canDelete: () => ActionHookResult;
+} {
+  const can = (item._can ?? {}) as Record<CrudAction, boolean>;
+
+  // Create a new object with the item as prototype, then define methods
+  const wrapped = Object.create(null);
+
+  // Copy all enumerable properties from the item
+  for (const [key, value] of Object.entries(item)) {
+    if (key === "_can") continue; // keep _can but don't expose it as top-level
+    Object.defineProperty(wrapped, key, {
+      value,
+      enumerable: true,
+      writable: true,
+      configurable: true,
+    });
+  }
+
+  // Preserve _can as non-enumerable for internal use
+  Object.defineProperty(wrapped, "_can", {
+    value: item._can,
+    enumerable: false,
+    writable: false,
+    configurable: false,
+  });
+
+  // Add permission methods as non-enumerable
+  Object.defineProperty(wrapped, "canRead", {
+    value: () => makeResult(can.read ?? false),
+    enumerable: false,
+    writable: false,
+    configurable: false,
+  });
+  Object.defineProperty(wrapped, "canCreate", {
+    value: () => makeResult(can.create ?? false),
+    enumerable: false,
+    writable: false,
+    configurable: false,
+  });
+  Object.defineProperty(wrapped, "canEdit", {
+    value: () => makeResult(can.update ?? false),
+    enumerable: false,
+    writable: false,
+    configurable: false,
+  });
+  Object.defineProperty(wrapped, "canDelete", {
+    value: () => makeResult(can.delete ?? false),
+    enumerable: false,
+    writable: false,
+    configurable: false,
+  });
+
+  return wrapped;
+}
+
+/**
+ * Wraps an array of items that have `_can` into a permission-aware collection.
+ *
+ * The returned value behaves like a normal array (indexing, `.map()`, etc.)
+ * but also has a `canAdd()` method that checks table-level create permission.
+ * Each item in the array is wrapped with `canEdit()`, `canDelete()`, etc.
+ *
+ * The `canAdd()` method reads from `_tablePerms` using the `_tableName`
+ * annotation that `cfastJson()` attaches to arrays.
+ */
+function wrapCollection<T extends Record<string, unknown>>(
+  arr: T[],
+  tablePerms: Record<string, Record<CrudAction, boolean>>,
+): T[] & {
+  canAdd: () => ActionHookResult;
+} {
+  // Wrap each item
+  const wrappedItems = arr.map((item) => {
+    if (item && typeof item === "object" && "_can" in item) {
+      return wrapItem(item);
+    }
+    return item;
+  });
+
+  // Determine table name from the non-enumerable _tableName annotation
+  const tableName = (arr as unknown as { _tableName?: string })._tableName;
+  const perms = tableName ? tablePerms[tableName] : undefined;
+
+  // Create the result as a proper array
+  const result = [...wrappedItems] as T[] & { canAdd: () => ActionHookResult };
+
+  // Preserve _tableName
+  if (tableName) {
+    Object.defineProperty(result, "_tableName", {
+      value: tableName,
+      enumerable: false,
+      writable: false,
+      configurable: false,
+    });
+  }
+
+  // Add canAdd method
+  Object.defineProperty(result, "canAdd", {
+    value: () => makeResult(perms?.create ?? false),
+    enumerable: false,
+    writable: false,
+    configurable: false,
+  });
+
+  return result;
+}
+
+/**
+ * Client hook that replaces `useLoaderData()` for routes using `cfastJson()`.
+ *
+ * Returns the same data but wraps arrays and objects that have `_can` with
+ * permission helper methods:
+ *
+ * - **Collections** (arrays with items that have `_can`): array works normally
+ *   (indexing, `.map()`, etc.) AND has `canAdd()`. Each item has `canEdit()`,
+ *   `canDelete()`, `canRead()`, `canCreate()`.
+ * - **Items** (objects with `_can`): row properties directly accessible,
+ *   plus `canEdit()`, `canDelete()`, `canRead()`, `canCreate()`.
+ * - **Other fields**: passed through unchanged.
+ *
+ * Each `can*()` method returns an {@link ActionHookResult}.
+ *
+ * @example
+ * ```tsx
+ * const { documents } = useCfastLoader<typeof loader>();
+ *
+ * // Collection-level
+ * documents.canAdd()          // -> ActionHookResult
+ *
+ * // Row fields accessible directly
+ * documents[0].title          // "Hello World"
+ *
+ * // Row-level
+ * documents[0].canEdit()      // -> ActionHookResult
+ * documents[0].canDelete()    // -> ActionHookResult
+ * ```
+ */
+export function useCfastLoader<
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  T extends (...args: any[]) => any = () => Record<string, unknown>,
+>(): ReturnType<T> extends Promise<infer R> ? R : ReturnType<T> {
+  const raw = useLoaderData() as Record<string, unknown>;
+  const tablePerms = (raw._tablePerms ?? {}) as Record<
+    string,
+    Record<CrudAction, boolean>
+  >;
+
+  const result: Record<string, unknown> = {};
+
+  for (const [key, value] of Object.entries(raw)) {
+    if (key === "_tablePerms") {
+      // Don't expose _tablePerms to the consumer directly
+      continue;
+    }
+
+    if (Array.isArray(value)) {
+      // Check if items have _can — wrap as collection
+      const hasCanItems =
+        value.length > 0 &&
+        value[0] !== null &&
+        typeof value[0] === "object" &&
+        "_can" in value[0];
+
+      if (hasCanItems) {
+        result[key] = wrapCollection(value as Record<string, unknown>[], tablePerms);
+      } else {
+        result[key] = value;
+      }
+    } else if (
+      value !== null &&
+      typeof value === "object" &&
+      !Array.isArray(value) &&
+      "_can" in value
+    ) {
+      // Single item with _can — wrap as item
+      result[key] = wrapItem(value as Record<string, unknown>);
+    } else {
+      // Pass through
+      result[key] = value;
+    }
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return result as any;
+}

--- a/packages/actions/src/client/use-cfast-loader.ts
+++ b/packages/actions/src/client/use-cfast-loader.ts
@@ -1,3 +1,4 @@
+import { useMemo } from "react";
 import { useLoaderData } from "react-router";
 import type { ActionHookResult } from "./use-actions.js";
 
@@ -183,46 +184,52 @@ export function useCfastLoader<
   T extends (...args: any[]) => any = () => Record<string, unknown>,
 >(): ReturnType<T> extends Promise<infer R> ? R : ReturnType<T> {
   const raw = useLoaderData() as Record<string, unknown>;
-  const tablePerms = (raw._tablePerms ?? {}) as Record<
-    string,
-    Record<CrudAction, boolean>
-  >;
 
-  const result: Record<string, unknown> = {};
+  // Memoize the wrapped result so that consumers receive stable references
+  // between renders. useLoaderData() returns the same object reference until
+  // the route's loader data is revalidated, so `raw` is a safe dependency.
+  return useMemo(() => {
+    const tablePerms = (raw._tablePerms ?? {}) as Record<
+      string,
+      Record<CrudAction, boolean>
+    >;
 
-  for (const [key, value] of Object.entries(raw)) {
-    if (key === "_tablePerms") {
-      // Don't expose _tablePerms to the consumer directly
-      continue;
-    }
+    const result: Record<string, unknown> = {};
 
-    if (Array.isArray(value)) {
-      // Check if items have _can — wrap as collection
-      const hasCanItems =
-        value.length > 0 &&
-        value[0] !== null &&
-        typeof value[0] === "object" &&
-        "_can" in value[0];
+    for (const [key, value] of Object.entries(raw)) {
+      if (key === "_tablePerms") {
+        // Don't expose _tablePerms to the consumer directly
+        continue;
+      }
 
-      if (hasCanItems) {
-        result[key] = wrapCollection(value as Record<string, unknown>[], tablePerms);
+      if (Array.isArray(value)) {
+        // Check if items have _can — wrap as collection
+        const hasCanItems =
+          value.length > 0 &&
+          value[0] !== null &&
+          typeof value[0] === "object" &&
+          "_can" in value[0];
+
+        if (hasCanItems) {
+          result[key] = wrapCollection(value as Record<string, unknown>[], tablePerms);
+        } else {
+          result[key] = value;
+        }
+      } else if (
+        value !== null &&
+        typeof value === "object" &&
+        !Array.isArray(value) &&
+        "_can" in value
+      ) {
+        // Single item with _can — wrap as item
+        result[key] = wrapItem(value as Record<string, unknown>);
       } else {
+        // Pass through
         result[key] = value;
       }
-    } else if (
-      value !== null &&
-      typeof value === "object" &&
-      !Array.isArray(value) &&
-      "_can" in value
-    ) {
-      // Single item with _can — wrap as item
-      result[key] = wrapItem(value as Record<string, unknown>);
-    } else {
-      // Pass through
-      result[key] = value;
     }
-  }
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  return result as any;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return result as any;
+  }, [raw]);
 }

--- a/packages/actions/src/index.ts
+++ b/packages/actions/src/index.ts
@@ -1,5 +1,6 @@
 /** @module actions */
 export { createActions, checkPermissionStatus } from "./create-actions.js";
+export { cfastJson } from "./cfast-json.js";
 export {
   defineInput,
   InvalidInputError,

--- a/packages/admin/package.json
+++ b/packages/admin/package.json
@@ -47,7 +47,7 @@
     "@cfast/db": ">=0.3.0 <0.5.0",
     "@cfast/forms": ">=0.2.0 <0.4.0",
     "@cfast/joy": ">=0.1.0 <0.3.0",
-    "@cfast/permissions": ">=0.3.0 <0.6.0",
+    "@cfast/permissions": ">=0.3.0 <0.7.0",
     "@cfast/ui": ">=0.2.0 <0.4.0",
     "@mui/joy": ">=5.0.0-beta.0",
     "react": ">=19",

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -65,7 +65,7 @@
   },
   "peerDependencies": {
     "@better-auth/passkey": ">=1",
-    "@cfast/permissions": ">=0.3.0 <0.6.0",
+    "@cfast/permissions": ">=0.3.0 <0.7.0",
     "better-auth": ">=1",
     "drizzle-orm": ">=0.35",
     "react": ">=18"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -49,7 +49,7 @@
   },
   "peerDependencies": {
     "@cfast/env": ">=0.1.0 <0.3.0",
-    "@cfast/permissions": ">=0.3.0 <0.6.0",
+    "@cfast/permissions": ">=0.3.0 <0.7.0",
     "react": ">=18"
   },
   "peerDependenciesMeta": {

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -51,7 +51,7 @@
     "@faker-js/faker": "^9.0.0"
   },
   "peerDependencies": {
-    "@cfast/permissions": ">=0.3.0 <0.6.0",
+    "@cfast/permissions": ">=0.3.0 <0.7.0",
     "drizzle-orm": ">=0.35"
   },
   "peerDependenciesMeta": {

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -36,4 +36,5 @@ export type {
   TransactionResult,
   Tx,
   WithCan,
+  CrudAction,
 } from "./types";

--- a/packages/db/src/types.ts
+++ b/packages/db/src/types.ts
@@ -10,6 +10,15 @@ import type {
 // --- _can annotation ---
 
 /**
+ * The four CRUD actions used as keys in `_can` annotations.
+ *
+ * Matches the `CrudAction` type from `@cfast/permissions`. Redefined here
+ * so `@cfast/db` does not import a runtime dependency from permissions just
+ * for a type alias.
+ */
+export type CrudAction = "read" | "create" | "update" | "delete";
+
+/**
  * Augments a row type with a `_can` object containing per-action booleans.
  *
  * Every query result from `findMany` / `findFirst` includes `_can` when the
@@ -18,7 +27,7 @@ import type {
  * when the grant has a `where` clause.
  */
 export type WithCan<T> = T & {
-  _can: Record<string, boolean>;
+  _can: Record<CrudAction, boolean>;
 };
 
 // --- Row inference helpers ---

--- a/packages/joy/src/action-button.tsx
+++ b/packages/joy/src/action-button.tsx
@@ -1,5 +1,5 @@
 import { type ReactElement } from "react";
-import { useFetcher, useNavigate } from "react-router";
+import { useFetcher } from "react-router";
 import JoyButton from "@mui/joy/Button";
 import type { ButtonProps as JoyButtonProps } from "@mui/joy/Button";
 import JoyTooltip from "@mui/joy/Tooltip";
@@ -46,7 +46,6 @@ export function ActionButton({
   ...buttonProps
 }: JoyActionButtonProps): ReactElement | null {
   const fetcher = useFetcher();
-  const navigate = useNavigate();
 
   if (action.invisible) {
     return null;
@@ -86,15 +85,16 @@ export function ActionButton({
     }
 
     return (
-      <JoyButton
-        {...buttonProps}
-        onClick={() => navigate(href)}
-        variant={variant}
-        color={color}
-        size={size}
-      >
-        {children}
-      </JoyButton>
+      <a href={href} style={{ textDecoration: "none" }}>
+        <JoyButton
+          {...buttonProps}
+          variant={variant}
+          color={color}
+          size={size}
+        >
+          {children}
+        </JoyButton>
+      </a>
     );
   }
 

--- a/packages/joy/src/action-button.tsx
+++ b/packages/joy/src/action-button.tsx
@@ -58,7 +58,8 @@ export function ActionButton({
   const disabled = !action.permitted && whenForbidden === "disable";
   const pending = action.pending || fetcher.state !== "idle";
 
-  // Navigation mode: render as a Link
+  // Navigation mode: render the Button as an anchor element to avoid
+  // invalid <a><button></button></a> nesting that causes hydration errors.
   if (href) {
     if (disabled) {
       const disabledButton = (
@@ -85,16 +86,15 @@ export function ActionButton({
     }
 
     return (
-      <a href={href} style={{ textDecoration: "none" }}>
-        <JoyButton
-          {...buttonProps}
-          variant={variant}
-          color={color}
-          size={size}
-        >
-          {children}
-        </JoyButton>
-      </a>
+      <JoyButton
+        {...buttonProps}
+        {...({ component: "a", href } as Record<string, unknown>)}
+        variant={variant}
+        color={color}
+        size={size}
+      >
+        {children}
+      </JoyButton>
     );
   }
 

--- a/packages/joy/src/action-button.tsx
+++ b/packages/joy/src/action-button.tsx
@@ -1,4 +1,5 @@
 import { type ReactElement } from "react";
+import { useFetcher, useNavigate } from "react-router";
 import JoyButton from "@mui/joy/Button";
 import type { ButtonProps as JoyButtonProps } from "@mui/joy/Button";
 import JoyTooltip from "@mui/joy/Tooltip";
@@ -11,25 +12,42 @@ type JoyActionButtonProps = {
   children: ReactNode;
   whenForbidden?: WhenForbidden;
   confirmation?: string | ConfirmOptions;
+  /**
+   * When provided, renders a permission-gated Link instead of a form button.
+   */
+  href?: string;
+  /**
+   * When provided, submits a form with these values as hidden fields via
+   * a fetcher. Eliminates manual `<Form>` + `<input type="hidden">`.
+   */
+  input?: Record<string, string | number | boolean | null | undefined>;
 } & Omit<JoyButtonProps, "children" | "onClick" | "disabled" | "loading" | "action">;
 
 /**
  * Joy UI styled ActionButton.
  *
- * Takes an `ActionHookResult` from `useActions()` — no hooks inside,
- * pure presentation component. All Joy Button props (sx, fullWidth, etc.)
- * are forwarded to the underlying Button.
+ * Takes an `ActionHookResult` from `useActions()` or `useCfastLoader()`.
+ * All Joy Button props (sx, fullWidth, etc.) are forwarded to the underlying
+ * Button.
+ *
+ * When `href` is provided, renders as a Link (permission-gated).
+ * When `input` is provided, submits form data via a fetcher.
  */
 export function ActionButton({
   action,
   children,
   whenForbidden = "disable",
   confirmation: _confirmation,
+  href,
+  input,
   variant = "solid",
   color = "primary",
   size = "md",
   ...buttonProps
 }: JoyActionButtonProps): ReactElement | null {
+  const fetcher = useFetcher();
+  const navigate = useNavigate();
+
   if (action.invisible) {
     return null;
   }
@@ -39,13 +57,68 @@ export function ActionButton({
   }
 
   const disabled = !action.permitted && whenForbidden === "disable";
+  const pending = action.pending || fetcher.state !== "idle";
+
+  // Navigation mode: render as a Link
+  if (href) {
+    if (disabled) {
+      const disabledButton = (
+        <JoyButton
+          {...buttonProps}
+          disabled
+          variant={variant}
+          color={color}
+          size={size}
+        >
+          {children}
+        </JoyButton>
+      );
+
+      if (action.reason) {
+        return (
+          <JoyTooltip title={action.reason}>
+            <span>{disabledButton}</span>
+          </JoyTooltip>
+        );
+      }
+
+      return disabledButton;
+    }
+
+    return (
+      <JoyButton
+        {...buttonProps}
+        onClick={() => navigate(href)}
+        variant={variant}
+        color={color}
+        size={size}
+      >
+        {children}
+      </JoyButton>
+    );
+  }
+
+  // Form data mode: submit with input values via fetcher
+  const handleClick = () => {
+    if (input) {
+      const formData = new FormData();
+      for (const [key, value] of Object.entries(input)) {
+        if (value !== null && value !== undefined) {
+          formData.set(key, String(value));
+        }
+      }
+      fetcher.submit(formData, { method: "POST" });
+    } else {
+      action.submit();
+    }
+  };
 
   const button = (
     <JoyButton
       {...buttonProps}
-      onClick={() => action.submit()}
+      onClick={handleClick}
       disabled={disabled}
-      loading={action.pending}
+      loading={pending}
       variant={variant}
       color={color}
       size={size}

--- a/packages/permissions/llms.txt
+++ b/packages/permissions/llms.txt
@@ -229,6 +229,18 @@ Used internally by `@cfast/db` to build row-level `_can` annotations on query re
 const CRUD_ACTIONS: readonly CrudAction[] = ["read", "create", "update", "delete"];
 ```
 
+### `resolveTablePermissions(grants, schema): Record<string, Record<CrudAction, boolean>>`
+```typescript
+import { resolveTablePermissions } from "@cfast/permissions";
+import * as schema from "../db/schema";
+
+const perms = resolveTablePermissions(grants, schema);
+// { posts: { read: true, create: true, update: false, delete: false }, ... }
+```
+Pure grant-structural check for every table in the schema. No DB, no SQL. Returns a serializable map. Skips non-table entries (e.g. relation objects) and deduplicates when multiple JS keys map to the same SQL name.
+
+Used internally by `cfastJson()` from `@cfast/actions` to embed table permissions in loader data.
+
 ### Client entrypoint
 ```typescript
 import { ForbiddenError, can } from "@cfast/permissions/client";

--- a/packages/permissions/src/__tests__/resolve-table-permissions.test.ts
+++ b/packages/permissions/src/__tests__/resolve-table-permissions.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from "vitest";
+import { resolveTablePermissions } from "../resolve-table-permissions";
+import { definePermissions } from "../define-permissions";
+import { resolveGrants } from "../resolve-grants";
+import { grant } from "../grant";
+import type { DrizzleTable } from "../types";
+
+const DRIZZLE_NAME = Symbol.for("drizzle:Name");
+const posts: DrizzleTable = { [DRIZZLE_NAME]: "posts" };
+const comments: DrizzleTable = { [DRIZZLE_NAME]: "comments" };
+const auditLogs: DrizzleTable = { [DRIZZLE_NAME]: "audit_logs" };
+
+const schema = { posts, comments, auditLogs } as Record<string, DrizzleTable>;
+
+const permissions = definePermissions({
+  roles: ["anonymous", "author", "admin"] as const,
+  hierarchy: {
+    author: ["anonymous"],
+    admin: ["author"],
+  },
+  grants: {
+    anonymous: [grant("read", posts)],
+    author: [grant("create", posts), grant("read", comments), grant("create", comments)],
+    admin: [grant("manage", "all")],
+  },
+});
+
+function grantsFor(role: string) {
+  return resolveGrants(permissions, [role]);
+}
+
+describe("resolveTablePermissions", () => {
+  it("returns CRUD booleans for every table in the schema", () => {
+    const result = resolveTablePermissions(grantsFor("anonymous"), schema);
+
+    expect(Object.keys(result).sort()).toEqual(["audit_logs", "comments", "posts"]);
+    expect(result.posts).toEqual({ read: true, create: false, update: false, delete: false });
+    expect(result.comments).toEqual({ read: false, create: false, update: false, delete: false });
+    expect(result.audit_logs).toEqual({ read: false, create: false, update: false, delete: false });
+  });
+
+  it("includes inherited grants via hierarchy", () => {
+    const result = resolveTablePermissions(grantsFor("author"), schema);
+
+    expect(result.posts).toEqual({ read: true, create: true, update: false, delete: false });
+    expect(result.comments).toEqual({ read: true, create: true, update: false, delete: false });
+  });
+
+  it("manage:all grants full CRUD on every table", () => {
+    const result = resolveTablePermissions(grantsFor("admin"), schema);
+
+    for (const tableName of Object.keys(result)) {
+      expect(result[tableName]).toEqual({ read: true, create: true, update: true, delete: true });
+    }
+  });
+
+  it("returns an empty map for an empty schema", () => {
+    const result = resolveTablePermissions(grantsFor("admin"), {});
+    expect(result).toEqual({});
+  });
+
+  it("returns all false for empty grants", () => {
+    const result = resolveTablePermissions([], schema);
+
+    for (const tableName of Object.keys(result)) {
+      expect(result[tableName]).toEqual({ read: false, create: false, update: false, delete: false });
+    }
+  });
+
+  it("skips non-table entries in schema (no drizzle:Name symbol)", () => {
+    const schemaWithRelations = {
+      posts,
+      // Relations objects don't have the drizzle:Name symbol
+      postsRelations: { someField: true } as unknown as DrizzleTable,
+    } as Record<string, DrizzleTable>;
+
+    const result = resolveTablePermissions(grantsFor("admin"), schemaWithRelations);
+    // Should only have "posts", not "unknown"
+    expect(Object.keys(result)).toEqual(["posts"]);
+  });
+
+  it("deduplicates when multiple JS keys map to the same SQL name", () => {
+    const duplicateSchema = {
+      posts,
+      postsAlias: posts, // same object, same drizzle:Name
+    } as Record<string, DrizzleTable>;
+
+    const result = resolveTablePermissions(grantsFor("author"), duplicateSchema);
+    expect(Object.keys(result)).toEqual(["posts"]);
+  });
+});

--- a/packages/permissions/src/index.ts
+++ b/packages/permissions/src/index.ts
@@ -7,6 +7,7 @@ export { resolveGrants } from "./resolve-grants";
 export type { UserWithRoles } from "./resolve-grants";
 export { getGrantedActions } from "./granted-actions";
 export type { GrantedAction } from "./granted-actions";
+export { resolveTablePermissions } from "./resolve-table-permissions";
 export { ForbiddenError, PermissionRegistrationError } from "./errors";
 export { CRUD_ACTIONS, getTableName } from "./types";
 export type {

--- a/packages/permissions/src/resolve-table-permissions.ts
+++ b/packages/permissions/src/resolve-table-permissions.ts
@@ -1,0 +1,52 @@
+import type { Grant, CrudAction, SchemaMap } from "./types";
+import { CRUD_ACTIONS, getTableName } from "./types";
+import { can } from "./can";
+
+/**
+ * Resolves table-level CRUD permissions for every table in a schema.
+ *
+ * Iterates each key in the schema map, extracts its table name, and calls
+ * {@link can} for each of the four CRUD actions (`read`, `create`, `update`,
+ * `delete`). Returns a flat, serializable map suitable for embedding in
+ * loader data and sending to the client.
+ *
+ * This is a pure grant-structural check — no database access, no SQL.
+ * Row-level `where` clauses on grants are ignored; the result reflects
+ * whether the user has *any* grant for the action on the table.
+ *
+ * @param grants - The user's resolved permission grants.
+ * @param schema - A schema map (e.g. `import * as schema from "./schema"`).
+ * @returns A record keyed by SQL table name, each mapping CRUD actions to booleans.
+ *
+ * @example
+ * ```ts
+ * import { resolveTablePermissions } from "@cfast/permissions";
+ * import * as schema from "../db/schema";
+ *
+ * const perms = resolveTablePermissions(grants, schema);
+ * // { posts: { read: true, create: true, update: false, delete: false }, ... }
+ * ```
+ */
+export function resolveTablePermissions(
+  grants: Grant[],
+  schema: SchemaMap,
+): Record<string, Record<CrudAction, boolean>> {
+  const result: Record<string, Record<CrudAction, boolean>> = {};
+
+  for (const key of Object.keys(schema)) {
+    const table = schema[key];
+    const tableName = getTableName(table);
+    // Skip non-table entries (e.g. relations objects) that resolve to "unknown"
+    if (tableName === "unknown") continue;
+    // Avoid duplicates when multiple JS keys map to the same SQL name
+    if (result[tableName]) continue;
+
+    const perms = {} as Record<CrudAction, boolean>;
+    for (const action of CRUD_ACTIONS) {
+      perms[action] = can(grants, action, table);
+    }
+    result[tableName] = perms;
+  }
+
+  return result;
+}

--- a/packages/ui/llms.txt
+++ b/packages/ui/llms.txt
@@ -51,7 +51,7 @@ useColumnInference(table: Record<string, unknown> | undefined, columns?: string[
 - `NavigationProgress` -- thin progress bar during React Router navigation.
 
 **Actions & feedback:**
-- `ActionButton` -- permission-aware button wrapping a `@cfast/actions` action. Props: `action`, `input`, `whenForbidden: "hide" | "disable" | "show"`, `confirmation`.
+- `ActionButton` -- permission-aware button wrapping a `@cfast/actions` action. Props: `action`, `whenForbidden: "hide" | "disable" | "show"`, `confirmation`, `href` (render as link), `input` (submit form data via fetcher).
 - `PermissionGate` -- conditional render based on action permissions. Props: `action`, `input`, `fallback`.
 - `ConfirmDialog` -- standalone confirmation dialog.
 - `ToastProvider` -- mount once in root layout for toast notifications.

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -48,7 +48,7 @@
     "@cfast/auth": ">=0.3.0 <0.5.0",
     "@cfast/db": ">=0.3.0 <0.5.0",
     "@cfast/pagination": ">=0.2.0 <0.4.0",
-    "@cfast/permissions": ">=0.3.0 <0.6.0",
+    "@cfast/permissions": ">=0.3.0 <0.7.0",
     "@cfast/storage": ">=0.1.0 <0.3.0",
     "react": ">=19",
     "react-dom": ">=19",

--- a/packages/ui/src/components/action-button.test.tsx
+++ b/packages/ui/src/components/action-button.test.tsx
@@ -1,9 +1,23 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
 import { render, screen, cleanup, fireEvent } from "@testing-library/react";
-import { ActionButton } from "./action-button.js";
 import type { ActionHookResult } from "@cfast/actions/client";
 
-afterEach(cleanup);
+const mockFetcherSubmit = vi.fn();
+
+vi.mock("react-router", () => ({
+  useFetcher: () => ({
+    state: "idle",
+    data: undefined,
+    submit: mockFetcherSubmit,
+  }),
+}));
+
+const { ActionButton } = await import("./action-button.js");
+
+afterEach(() => {
+  cleanup();
+  mockFetcherSubmit.mockClear();
+});
 
 function mockAction(overrides: Partial<ActionHookResult> = {}): ActionHookResult {
   return {
@@ -91,5 +105,107 @@ describe("ActionButton", () => {
 
     fireEvent.click(button);
     expect(submitFn).toHaveBeenCalled();
+  });
+
+  describe("href prop", () => {
+    it("renders a link wrapping a button when href is provided and permitted", () => {
+      const action = mockAction();
+
+      const { container } = render(
+        <ActionButton action={action} href="/documents/new">
+          New Document
+        </ActionButton>,
+      );
+
+      const link = container.querySelector("a");
+      expect(link).not.toBeNull();
+      expect(link!.getAttribute("href")).toBe("/documents/new");
+      expect(screen.getByRole("button").textContent).toBe("New Document");
+    });
+
+    it("renders a disabled button when href is provided but not permitted", () => {
+      const action = mockAction({ permitted: false, reason: "No permission" });
+
+      const { container } = render(
+        <ActionButton action={action} href="/documents/new">
+          New Document
+        </ActionButton>,
+      );
+
+      // No link rendered when disabled
+      const link = container.querySelector("a");
+      expect(link).toBeNull();
+
+      const button = screen.getByRole("button");
+      expect((button as HTMLButtonElement).disabled).toBe(true);
+    });
+
+    it("hides when href is provided, not permitted, and whenForbidden=hide", () => {
+      const action = mockAction({ permitted: false });
+
+      const { container } = render(
+        <ActionButton action={action} href="/documents/new" whenForbidden="hide">
+          New Document
+        </ActionButton>,
+      );
+
+      expect(container.innerHTML).toBe("");
+    });
+  });
+
+  describe("input prop", () => {
+    it("submits form data via fetcher when input is provided", () => {
+      const action = mockAction();
+
+      render(
+        <ActionButton
+          action={action}
+          input={{ _action: "deletePost", id: "123" }}
+        >
+          Delete
+        </ActionButton>,
+      );
+
+      fireEvent.click(screen.getByRole("button"));
+
+      // Should use the fetcher submit, not the action's submit
+      expect(mockFetcherSubmit).toHaveBeenCalledTimes(1);
+      const submittedData = mockFetcherSubmit.mock.calls[0][0] as FormData;
+      expect(submittedData.get("_action")).toBe("deletePost");
+      expect(submittedData.get("id")).toBe("123");
+    });
+
+    it("does not include null/undefined values in form data", () => {
+      const action = mockAction();
+
+      render(
+        <ActionButton
+          action={action}
+          input={{ _action: "update", name: "test", optional: null }}
+        >
+          Update
+        </ActionButton>,
+      );
+
+      fireEvent.click(screen.getByRole("button"));
+
+      const submittedData = mockFetcherSubmit.mock.calls[0][0] as FormData;
+      expect(submittedData.get("_action")).toBe("update");
+      expect(submittedData.get("name")).toBe("test");
+      expect(submittedData.has("optional")).toBe(false);
+    });
+
+    it("uses action.submit() when input is not provided", () => {
+      const submitFn = vi.fn();
+      const action = mockAction({ submit: submitFn });
+
+      render(
+        <ActionButton action={action}>Submit</ActionButton>,
+      );
+
+      fireEvent.click(screen.getByRole("button"));
+      expect(submitFn).toHaveBeenCalled();
+      expect(mockFetcherSubmit).not.toHaveBeenCalled();
+    });
   });
 });

--- a/packages/ui/src/components/action-button.tsx
+++ b/packages/ui/src/components/action-button.tsx
@@ -1,3 +1,4 @@
+import { useFetcher } from "react-router";
 import { useComponent } from "../plugin.js";
 import type { ActionButtonProps } from "../types.js";
 
@@ -13,16 +14,39 @@ import type { ActionButtonProps } from "../types.js";
  * - `whenForbidden="disable"` -- shown but disabled when not permitted (default)
  * - `whenForbidden="show"` -- shown and clickable regardless of permission
  *
+ * When `href` is provided, renders a permission-gated `<a>` link instead of
+ * a form-submitting button. The link is only rendered when the action is
+ * permitted (respects `whenForbidden`).
+ *
+ * When `input` is provided, submits a form with those values as hidden
+ * fields via a fetcher, eliminating manual `<Form>` + `<input type="hidden">`.
+ * This works with both `useActions()` results (where `action.submit()` is
+ * already wired) and `useCfastLoader()` results (where `action.submit()`
+ * is a no-op and the fetcher handles submission).
+ *
  * @param props - See {@link ActionButtonProps}.
  *
- * @example
+ * @example Basic form submission
+ * ```tsx
+ * <ActionButton action={publishPost} confirmation="Publish this post?">
+ *   Publish
+ * </ActionButton>
+ * ```
+ *
+ * @example Navigation link (permission-gated)
+ * ```tsx
+ * <ActionButton action={documents.canAdd()} href="/documents/new">
+ *   New Document
+ * </ActionButton>
+ * ```
+ *
+ * @example Form data via input prop
  * ```tsx
  * <ActionButton
- *   action={publishPost}
- *   whenForbidden="disable"
- *   confirmation="Publish this post?"
+ *   action={recipe.canDelete()}
+ *   input={{ _action: "deleteRecipe", id: recipe.id }}
  * >
- *   Publish
+ *   Delete
  * </ActionButton>
  * ```
  */
@@ -31,9 +55,12 @@ export function ActionButton({
   children,
   whenForbidden = "disable",
   confirmation: _confirmation,
+  href,
+  input,
   ...buttonProps
 }: ActionButtonProps) {
   const Button = useComponent("button");
+  const fetcher = useFetcher();
 
   if (action.invisible) {
     return null;
@@ -44,13 +71,48 @@ export function ActionButton({
   }
 
   const disabled = !action.permitted && whenForbidden === "disable";
+  const pending = action.pending || fetcher.state !== "idle";
+
+  // Navigation mode: render as a link
+  if (href) {
+    if (disabled) {
+      return (
+        <Button {...buttonProps} disabled loading={false}>
+          {children}
+        </Button>
+      );
+    }
+
+    return (
+      <a href={href} style={{ textDecoration: "none" }}>
+        <Button {...buttonProps} disabled={false} loading={false}>
+          {children}
+        </Button>
+      </a>
+    );
+  }
+
+  // Form data mode: submit with input values via fetcher
+  const handleClick = () => {
+    if (input) {
+      const formData = new FormData();
+      for (const [key, value] of Object.entries(input)) {
+        if (value !== null && value !== undefined) {
+          formData.set(key, String(value));
+        }
+      }
+      fetcher.submit(formData, { method: "POST" });
+    } else {
+      action.submit();
+    }
+  };
 
   return (
     <Button
       {...buttonProps}
-      onClick={() => action.submit()}
+      onClick={handleClick}
       disabled={disabled}
-      loading={action.pending}
+      loading={pending}
     >
       {children}
     </Button>

--- a/packages/ui/src/types.ts
+++ b/packages/ui/src/types.ts
@@ -1168,6 +1168,16 @@ export type ActionButtonProps = {
   whenForbidden?: WhenForbidden;
   /** Confirmation message or options shown before executing the action. */
   confirmation?: string | ConfirmOptions;
+  /**
+   * When provided, renders a permission-gated link instead of a form button.
+   * The link navigates to `href` when the action is permitted.
+   */
+  href?: string;
+  /**
+   * When provided, submits a form with these values as hidden fields via
+   * `action.submit()`. Eliminates manual `<Form>` + `<input type="hidden">`.
+   */
+  input?: Record<string, string | number | boolean | null | undefined>;
 } & Omit<ButtonSlotProps, ActionButtonControlledProps>;
 
 // --- PermissionGate ---


### PR DESCRIPTION
## Summary

- **@cfast/permissions**: Add `resolveTablePermissions(grants, schema)` -- returns `Record<tableName, Record<CrudAction, boolean>>` for every table in a schema. Pure grant-structural check, no DB.
- **@cfast/actions**: Add `cfastJson(grants, schema, data)` server helper -- embeds `_tablePerms` and serializes dates, replacing manual `can()` + `toJSON()` in loaders.
- **@cfast/actions/client**: Add `useCfastLoader<T>()` hook -- wraps `_can` arrays/objects with `canEdit()`, `canDelete()`, `canRead()`, `canCreate()`, `canAdd()` methods returning `ActionHookResult`. Row properties directly accessible (no `.data` wrapper).
- **@cfast/ui + @cfast/joy**: `ActionButton` gains `href` prop (permission-gated link) and `input` prop (submit form data via fetcher), eliminating manual `<Form>` + `<input type="hidden">` boilerplate.
- **@cfast/db**: `WithCan<T>` now uses `Record<CrudAction, boolean>` instead of `Record<string, boolean>` for stricter typing.
- **team-blog-after**: Adopts `cfastJson`, `useCfastLoader`, and `ActionButton href` in 3 routes (home, post detail, profile).
- **Docs**: Updated llms.txt, llms-full.txt, per-package llms.txt, actions.mdx, permissions.mdx, CLAUDE.md anti-patterns.

## Test plan

- [x] `pnpm turbo build typecheck test lint` passes for all 5 changed packages (permissions, db, actions, ui, joy)
- [x] `pnpm --filter team-blog-after typecheck` passes
- [x] New tests: `resolve-table-permissions.test.ts` (7 tests), `cfast-json.test.ts` (7 tests), `use-cfast-loader.test.ts` (11 tests), `action-button.test.tsx` (6 new tests for href/input)
- [ ] `pnpm turbo test:e2e --filter=team-blog-after` (e2e after merge)

Fixes #286
Fixes #284

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)