### PR TITLE
fix: widen @cfast/* peer dependency ranges to <1.0.0

### DIFF
--- a/packages/actions/package.json
+++ b/packages/actions/package.json
@@ -45,8 +45,8 @@
     "test": "vitest run"
   },
   "peerDependencies": {
-    "@cfast/db": ">=0.3.0 <0.5.0",
-    "@cfast/permissions": ">=0.3.0 <0.7.0",
+    "@cfast/db": ">=0.1.0 <1.0.0",
+    "@cfast/permissions": ">=0.1.0 <1.0.0",
     "react": "^19.0.0",
     "react-router": "^7.0.0"
   },

--- a/packages/admin/package.json
+++ b/packages/admin/package.json
@@ -44,11 +44,11 @@
     "test": "vitest run"
   },
   "peerDependencies": {
-    "@cfast/db": ">=0.3.0 <0.5.0",
-    "@cfast/forms": ">=0.2.0 <0.4.0",
-    "@cfast/joy": ">=0.1.0 <0.3.0",
-    "@cfast/permissions": ">=0.3.0 <0.7.0",
-    "@cfast/ui": ">=0.2.0 <0.4.0",
+    "@cfast/db": ">=0.1.0 <1.0.0",
+    "@cfast/forms": ">=0.1.0 <1.0.0",
+    "@cfast/joy": ">=0.1.0 <1.0.0",
+    "@cfast/permissions": ">=0.1.0 <1.0.0",
+    "@cfast/ui": ">=0.1.0 <1.0.0",
     "@mui/joy": ">=5.0.0-beta.0",
     "react": ">=19",
     "react-dom": ">=19",

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -65,7 +65,7 @@
   },
   "peerDependencies": {
     "@better-auth/passkey": ">=1",
-    "@cfast/permissions": ">=0.3.0 <0.7.0",
+    "@cfast/permissions": ">=0.1.0 <1.0.0",
     "better-auth": ">=1",
     "drizzle-orm": ">=0.35",
     "react": ">=18"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -48,8 +48,8 @@
     "test": "vitest run --passWithNoTests"
   },
   "peerDependencies": {
-    "@cfast/env": ">=0.1.0 <0.3.0",
-    "@cfast/permissions": ">=0.3.0 <0.7.0",
+    "@cfast/env": ">=0.1.0 <1.0.0",
+    "@cfast/permissions": ">=0.1.0 <1.0.0",
     "react": ">=18"
   },
   "peerDependenciesMeta": {

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -51,7 +51,7 @@
     "@faker-js/faker": "^9.0.0"
   },
   "peerDependencies": {
-    "@cfast/permissions": ">=0.3.0 <0.7.0",
+    "@cfast/permissions": ">=0.1.0 <1.0.0",
     "drizzle-orm": ">=0.35"
   },
   "peerDependenciesMeta": {

--- a/packages/joy/package.json
+++ b/packages/joy/package.json
@@ -35,9 +35,9 @@
     "build-storybook": "storybook build"
   },
   "peerDependencies": {
-    "@cfast/actions": ">=0.1.0 <0.3.0",
-    "@cfast/auth": ">=0.3.0 <0.5.0",
-    "@cfast/ui": ">=0.2.0 <0.4.0",
+    "@cfast/actions": ">=0.1.0 <1.0.0",
+    "@cfast/auth": ">=0.1.0 <1.0.0",
+    "@cfast/ui": ">=0.1.0 <1.0.0",
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.1",
     "@mui/joy": ">=5.0.0-beta.0",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -44,12 +44,12 @@
     "test": "vitest run"
   },
   "peerDependencies": {
-    "@cfast/actions": ">=0.1.0 <0.3.0",
-    "@cfast/auth": ">=0.3.0 <0.5.0",
-    "@cfast/db": ">=0.3.0 <0.5.0",
-    "@cfast/pagination": ">=0.2.0 <0.4.0",
-    "@cfast/permissions": ">=0.3.0 <0.7.0",
-    "@cfast/storage": ">=0.1.0 <0.3.0",
+    "@cfast/actions": ">=0.1.0 <1.0.0",
+    "@cfast/auth": ">=0.1.0 <1.0.0",
+    "@cfast/db": ">=0.1.0 <1.0.0",
+    "@cfast/pagination": ">=0.1.0 <1.0.0",
+    "@cfast/permissions": ">=0.1.0 <1.0.0",
+    "@cfast/storage": ">=0.1.0 <1.0.0",
     "react": ">=19",
     "react-dom": ">=19",
     "react-router": ">=7"


### PR DESCRIPTION
## Summary
- Widened all `@cfast/*` peer dependency ranges from narrow bounds (e.g. `>=0.3.0 <0.5.0`) to `>=0.1.0 <1.0.0` across 7 packages: actions, admin, auth, core, db, joy, ui
- This eliminates 15+ unmet peer dep warnings in demo apps and prevents the issue from recurring with every minor bump during pre-1.0 development
- Left `workspace:*` peer deps in `@cfast/forms` untouched (those are correct as-is)

Fixes #302

## Test plan
- [x] `pnpm install` succeeds (lockfile unchanged since workspace:* devDeps are unaffected)
- [x] `pnpm turbo build typecheck test lint` passes all 82 tasks
- [ ] Verify demo apps no longer show unmet peer dep warnings after publish

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)